### PR TITLE
Fix deprecated img_url tag

### DIFF
--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
     {%- if settings.favicon != blank -%}
-      <link rel="icon" type="image/png" href="{{ settings.favicon | img_url: '32x32' }}">
+      <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: width: 32 }}">
     {%- endif -%}
 
     {%- unless settings.type_header_font.system? -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
     {%- if settings.favicon != blank -%}
-      <link rel="icon" type="image/png" href="{{ settings.favicon | img_url: '32x32' }}">
+      <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: 32 }}">
     {%- endif -%}
 
     {%- unless settings.type_header_font.system? and settings.type_body_font.system? -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
     {%- if settings.favicon != blank -%}
-      <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: 32 }}">
+      <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: width: 32 }}">
     {%- endif -%}
 
     {%- unless settings.type_header_font.system? and settings.type_body_font.system? -%}

--- a/sections/cart-notification-product.liquid
+++ b/sections/cart-notification-product.liquid
@@ -4,7 +4,7 @@
       {%- if item.image -%}
         <div class="cart-notification-product__image global-media-settings">
           <img
-            src="{{ item.image | img_url: '140x' }}"
+            src="{{ item.image | image_url: width: 140 }}"
             alt="{{ item.image.alt | escape }}"
             width="70"
             height="{{ 70 | divided_by: item.image.aspect_ratio | ceil }}"

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -38,7 +38,7 @@
                         {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }},{%- endif -%}
                         {%- if block.settings.image.width >= 2200 -%}{{ block.settings.image | image_url: width: 2200 }},{%- endif -%}
                         {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
-                        {{ block.settings.image | image_url: width: 'master' }}"
+                        {{ block.settings.image | image_url: height: 'master', width: block.settings.image.width }}"
                       src="{{ block.settings.image | image_url: width: 1500 }}"
                       sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                       alt="{{ block.settings.image.alt | escape }}"
@@ -79,7 +79,7 @@
                             {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
                             {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
                             {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-                            {{ block.settings.cover_image | image_url: width: 'master' }}"
+                            {{ block.settings.cover_image | image_url: height: 'master', width: block.settings.cover_image.width }}"
                           src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                           sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                           alt="{{ block.settings.description | escape }}"
@@ -110,7 +110,7 @@
                               {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
                               {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
                               {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-                              {{ block.settings.cover_image | image_url: width: 'master' }}"
+                              {{ block.settings.cover_image | image_url: height: 'master', width: block.settings.cover_image.width }}"
                             src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                             sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                             alt="{{ block.settings.description | escape }}"

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -39,7 +39,7 @@
                         {%- if block.settings.image.width >= 2200 -%}{{ block.settings.image | image_url: width: 2200 }},{%- endif -%}
                         {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
                         {{ block.settings.image | image_url: width: 'master' }}"
-                      src="{{ block.settings.image | image_url: 1500 }}"
+                      src="{{ block.settings.image | image_url: width: 1500 }}"
                       sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                       alt="{{ block.settings.image.alt | escape }}"
                       loading="lazy"

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -31,14 +31,14 @@
                 <div class="media media--transparent ratio"{% if block.settings.image != blank %} style="--ratio-percent: {{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%"{% else %} style="--ratio-percent: 100%"{% endif %}>
                   {%- if block.settings.image != blank -%}
                     <img
-                      srcset="{%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 720 -%}{{ block.settings.image | image_url: width: 720 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | image_url: width: 990 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | image_url: width: 1100 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 2200 -%}{{ block.settings.image | image_url: width: 2200 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
-                        {{ block.settings.image | image_url: 'master' }}"
+                      srcset="{%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }} 550w,{%- endif -%}
+                        {%- if block.settings.image.width >= 720 -%}{{ block.settings.image | image_url: width: 720 }} 720w,{%- endif -%}
+                        {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | image_url: width: 990 }} 990w,{%- endif -%}
+                        {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | image_url: width: 1100 }} 1100w,{%- endif -%}
+                        {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }} 1500w,{%- endif -%}
+                        {%- if block.settings.image.width >= 2200 -%}{{ block.settings.image | image_url: width: 2200 }} 2200w,{%- endif -%}
+                        {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }} 3000w,{%- endif -%}
+                        {{ block.settings.image | image_url }} {{ block.settings.image.width }}w"
                       src="{{ block.settings.image | image_url: width: 1500 }}"
                       sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                       alt="{{ block.settings.image.alt | escape }}"
@@ -72,14 +72,14 @@
                     <div class="media media--transparent ratio"{% if block.settings.cover_image != blank %} style="--ratio-percent: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%"{% else %} style="--ratio-percent: 100%"{% endif %}>
                       {%- if block.settings.cover_image != blank -%}
                         <img
-                          srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | image_url: width: 550 }},{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | image_url: width: 720 }},{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | image_url: width: 990 }},{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-                            {{ block.settings.cover_image | image_url: 'master' }}"
+                          srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | image_url: width: 550 }} 550w,{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | image_url: width: 720 }} 720w,{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | image_url: width: 990 }} 990w,{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | image_url: width: 1100 }} 1100w,{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }} 1500w,{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }} 2200w,{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }} 3000w,{%- endif -%}
+                            {{ block.settings.cover_image | image_url }} {{ block.settings.cover_image}}w"
                           src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                           sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                           alt="{{ block.settings.description | escape }}"
@@ -103,14 +103,14 @@
   
                         {%- if block.settings.cover_image != blank -%}
                           <img
-                            srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | image_url: width: 550 }},{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | image_url: width: 720 }},{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | image_url: width: 990 }},{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-                              {{ block.settings.cover_image | image_url: 'master' }}"
+                            srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | image_url: width: 550 }} 550w,{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | image_url: width: 720 }} 720w,{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | image_url: width: 990 }} 990w,{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | image_url: width: 1100 }} 1100w,{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }} 1500w,{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }} 2200w,{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }} 3000w,{%- endif -%}
+                              {{ block.settings.cover_image | image_url }} {{ block.settings.cover_image }}w"
                             src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                             sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                             alt="{{ block.settings.description | escape }}"

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -38,7 +38,7 @@
                         {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }},{%- endif -%}
                         {%- if block.settings.image.width >= 2200 -%}{{ block.settings.image | image_url: width: 2200 }},{%- endif -%}
                         {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
-                        {{ block.settings.image | image_url: height: 'master', width: block.settings.image.width }}"
+                        {{ block.settings.image | image_url: 'master' }}"
                       src="{{ block.settings.image | image_url: width: 1500 }}"
                       sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                       alt="{{ block.settings.image.alt | escape }}"
@@ -79,7 +79,7 @@
                             {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
                             {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
                             {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-                            {{ block.settings.cover_image | image_url: height: 'master', width: block.settings.cover_image.width }}"
+                            {{ block.settings.cover_image | image_url: 'master' }}"
                           src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                           sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                           alt="{{ block.settings.description | escape }}"
@@ -110,7 +110,7 @@
                               {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
                               {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
                               {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-                              {{ block.settings.cover_image | image_url: height: 'master', width: block.settings.cover_image.width }}"
+                              {{ block.settings.cover_image | image_url: 'master' }}"
                             src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                             sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                             alt="{{ block.settings.description | escape }}"

--- a/sections/collage.liquid
+++ b/sections/collage.liquid
@@ -31,15 +31,15 @@
                 <div class="media media--transparent ratio"{% if block.settings.image != blank %} style="--ratio-percent: {{ 1 | divided_by: block.settings.image.aspect_ratio | times: 100 }}%"{% else %} style="--ratio-percent: 100%"{% endif %}>
                   {%- if block.settings.image != blank -%}
                     <img
-                      srcset="{%- if block.settings.image.width >= 550 -%}{{ block.settings.image | img_url: '550x' }} 550w,{%- endif -%}
-                        {%- if block.settings.image.width >= 720 -%}{{ block.settings.image | img_url: '720x' }} 720w,{%- endif -%}
-                        {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | img_url: '990x' }} 990w,{%- endif -%}
-                        {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | img_url: '1100x' }} 1100w,{%- endif -%}
-                        {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | img_url: '1500x' }} 1500w,{%- endif -%}
-                        {%- if block.settings.image.width >= 2200 -%}{{ block.settings.image | img_url: '2200x' }} 2200w,{%- endif -%}
-                        {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | img_url: '3000x' }} 3000w,{%- endif -%}
-                        {{ block.settings.image | img_url: 'master' }} {{ block.settings.image.width }}w"
-                      src="{{ block.settings.image | img_url: '1500x' }}"
+                      srcset="{%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 720 -%}{{ block.settings.image | image_url: width: 720 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 990 -%}{{ block.settings.image | image_url: width: 990 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | image_url: width: 1100 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 2200 -%}{{ block.settings.image | image_url: width: 2200 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
+                        {{ block.settings.image | image_url: width: 'master' }}"
+                      src="{{ block.settings.image | image_url: 1500 }}"
                       sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                       alt="{{ block.settings.image.alt | escape }}"
                       loading="lazy"
@@ -72,15 +72,15 @@
                     <div class="media media--transparent ratio"{% if block.settings.cover_image != blank %} style="--ratio-percent: {{ 1 | divided_by: block.settings.cover_image.aspect_ratio | times: 100 }}%"{% else %} style="--ratio-percent: 100%"{% endif %}>
                       {%- if block.settings.cover_image != blank -%}
                         <img
-                          srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | img_url: '550x' }} 550w,{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | img_url: '720x' }} 720w,{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | img_url: '1100x' }} 1100w,{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | img_url: '1500x' }} 1500w,{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | img_url: '2200x' }} 2200w,{%- endif -%}
-                            {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | img_url: '3000x' }} 3000w,{%- endif -%}
-                            {{ block.settings.cover_image | img_url: 'master' }} {{ block.settings.cover_image.width }}w"
-                          src="{{ block.settings.cover_image | img_url: '1500x' }}"
+                          srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | image_url: width: 550 }},{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | image_url: width: 720 }},{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | image_url: width: 990 }},{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
+                            {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
+                            {{ block.settings.cover_image | image_url: width: 'master' }}"
+                          src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                           sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                           alt="{{ block.settings.description | escape }}"
                           loading="lazy"
@@ -103,15 +103,15 @@
   
                         {%- if block.settings.cover_image != blank -%}
                           <img
-                            srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | img_url: '550x' }} 550w,{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | img_url: '720x' }} 720w,{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | img_url: '990x' }} 990w,{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | img_url: '1100x' }} 1100w,{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | img_url: '1500x' }} 1500w,{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | img_url: '2200x' }} 2200w,{%- endif -%}
-                              {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | img_url: '3000x' }} 3000w,{%- endif -%}
-                              {{ block.settings.cover_image | img_url: 'master' }} {{ block.settings.cover_image.width }}w"
-                            src="{{ block.settings.cover_image | img_url: '1500x' }}"
+                            srcset="{%- if block.settings.cover_image.width >= 550 -%}{{ block.settings.cover_image | image_url: width: 550 }},{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 720 -%}{{ block.settings.cover_image | image_url: width: 720 }},{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 990 -%}{{ block.settings.cover_image | image_url: width: 990 }},{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 1100 -%}{{ block.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 1500 -%}{{ block.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 2200 -%}{{ block.settings.cover_image | image_url: width: 2200 }},{%- endif -%}
+                              {%- if block.settings.cover_image.width >= 3000 -%}{{ block.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
+                              {{ block.settings.cover_image | image_url: width: 'master' }}"
+                            src="{{ block.settings.cover_image | image_url: width: 1500 }}"
                             sizes="(min-width: {{ settings.page_width }}px) {% if section.blocks.size == 1 %}calc({{ settings.page_width }}px - 100px){% else %}{{ settings.page_width | minus: 100 | times: 0.67 | round }}px{% endif %}, (min-width: 750px){% if section.blocks.size == 1 %} calc(100vw - 100px){% else %} 500px{% endif %}, calc(100vw - 30px)"
                             alt="{{ block.settings.description | escape }}"
                             loading="lazy"

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -43,7 +43,7 @@
                     {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
                     {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | image_url: width: 1250 }},{%- endif -%}
                     {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-                    {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
+                    {{ section.settings.image | image_url: 'master' }}"
                   src="{{ section.settings.image | image_url: width: 1500 }}"
                   sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                   alt="{{ section.settings.image.alt | escape }}"

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -36,14 +36,14 @@
                 {% if section.settings.image_ratio == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: section.settings.image.aspect_ratio | times: 100 }}%;"{% endif %}
               >
                 <img
-                  srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: width: 165 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: width: 360 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: width: 535 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | image_url: width: 1250 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-                    {{ section.settings.image | image_url: 'master' }}"
+                  srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: width: 165 }} 165w,{%- endif -%}
+                    {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: width: 360 }} 360w,{%- endif -%}
+                    {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: width: 535 }} 535w,{%- endif -%}
+                    {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }} 750w,{%- endif -%}
+                    {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }} 1070w,{%- endif -%}
+                    {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | image_url: width: 1250 }} 1250w,{%- endif -%}
+                    {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }} 1500w,{%- endif -%}
+                    {{ section.settings.image | image_url }} {{ section.settings.image.width }}w"
                   src="{{ section.settings.image | image_url: width: 1500 }}"
                   sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                   alt="{{ section.settings.image.alt | escape }}"

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -36,15 +36,15 @@
                 {% if section.settings.image_ratio == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: section.settings.image.aspect_ratio | times: 100 }}%;"{% endif %}
               >
                 <img
-                  srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: 165 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: 360 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: 535 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: 750 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: 1070 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | image_url: 1250 }},{%- endif -%}
-                    {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: 1500 }},{%- endif -%}
-                    {{ section.settings.image | image_url: 'master' }} {{ section.settings.image.width }}w"
-                  src="{{ section.settings.image | image_url: '1500x' }}"
+                  srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: width: 165 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: width: 360 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: width: 535 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | image_url: width: 1250 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
+                    {{ section.settings.image | image_url: width: 'master' }} {{ section.settings.image.width }}w"
+                  src="{{ section.settings.image | image_url: width: 1500 }}"
                   sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                   alt="{{ section.settings.image.alt | escape }}"
                   loading="lazy"

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -43,7 +43,7 @@
                     {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
                     {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | image_url: width: 1250 }},{%- endif -%}
                     {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-                    {{ section.settings.image | image_url: width: 'master' }} {{ section.settings.image.width }}w"
+                    {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
                   src="{{ section.settings.image | image_url: width: 1500 }}"
                   sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                   alt="{{ section.settings.image.alt | escape }}"

--- a/sections/collapsible-content.liquid
+++ b/sections/collapsible-content.liquid
@@ -36,15 +36,15 @@
                 {% if section.settings.image_ratio == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: section.settings.image.aspect_ratio | times: 100 }}%;"{% endif %}
               >
                 <img
-                  srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | img_url: '165x' }} 165w,{%- endif -%}
-                    {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | img_url: '360x' }} 360w,{%- endif -%}
-                    {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | img_url: '535x' }} 535w,{%- endif -%}
-                    {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | img_url: '750x' }} 750w,{%- endif -%}
-                    {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | img_url: '1070x' }} 1070w,{%- endif -%}
-                    {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | img_url: '1250x' }} 1250w,{%- endif -%}
-                    {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | img_url: '1500x' }} 1500w,{%- endif -%}
-                    {{ section.settings.image | img_url: 'master' }} {{ section.settings.image.width }}w"
-                  src="{{ section.settings.image | img_url: '1500x' }}"
+                  srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: 165 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: 360 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: 535 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: 750 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: 1070 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 1250 -%}{{ section.settings.image | image_url: 1250 }},{%- endif -%}
+                    {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: 1500 }},{%- endif -%}
+                    {{ section.settings.image | image_url: 'master' }} {{ section.settings.image.width }}w"
+                  src="{{ section.settings.image | image_url: '1500x' }}"
                   sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                   alt="{{ section.settings.image.alt | escape }}"
                   loading="lazy"

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -40,7 +40,7 @@
             {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
             {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
             {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
-            {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
+            {{ section.settings.image | image_url: 'master' }}"
           sizes="100vw"
           src="{{ section.settings.image | image_url: width: 1500 }}"
           loading="lazy"

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -32,15 +32,15 @@
     <div class="banner__media{% if section.settings.image != blank %} media{% endif %}">
       {%- if section.settings.image != blank -%}
         <img
-          srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | image_url: width: 375 }},{%- endif -%}
-            {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
-            {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | image_url: width: 1100 }} ,{%- endif -%}
-            {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-            {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | image_url: width: 1780 }},{%- endif -%}
-            {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
-            {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
-            {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
-            {{ section.settings.image | image_url: 'master' }}"
+          srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | image_url: width: 375 }} 375w,{%- endif -%}
+            {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }} 750w,{%- endif -%}
+            {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | image_url: width: 1100 }} 1100w,{%- endif -%}
+            {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }} 1500w,{%- endif -%}
+            {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | image_url: width: 1780 }} 1780w,{%- endif -%}
+            {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }} 2000w,{%- endif -%}
+            {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }} 3000w,{%- endif -%}
+            {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }} 3840w,{%- endif -%}
+            {{ section.settings.image | image_url }} {{section.settings.image.width }}w"
           sizes="100vw"
           src="{{ section.settings.image | image_url: width: 1500 }}"
           loading="lazy"

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -32,17 +32,17 @@
     <div class="banner__media{% if section.settings.image != blank %} media{% endif %}">
       {%- if section.settings.image != blank -%}
         <img
-          srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | img_url: '375x' }} 375w,{%- endif -%}
-            {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | img_url: '750x' }} 750w,{%- endif -%}
-            {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | img_url: '1100x' }} 1100w,{%- endif -%}
-            {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | img_url: '1500x' }} 1500w,{%- endif -%}
-            {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | img_url: '1780x' }} 1780w,{%- endif -%}
-            {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | img_url: '2000x' }} 2000w,{%- endif -%}
-            {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | img_url: '3000x' }} 3000w,{%- endif -%}
-            {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | img_url: '3840x' }} 3840w,{%- endif -%}
-            {{ section.settings.image | img_url: 'master' }} {{ section.settings.image.width }}w"
+          srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | image_url: width: 375 }},{%- endif -%}
+            {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
+            {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | image_url: width: 1100 }} ,{%- endif -%}
+            {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
+            {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | image_url: width: 1780 }},{%- endif -%}
+            {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
+            {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
+            {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
+            {{ section.settings.image | image_url: width: 'master' }}"
           sizes="100vw"
-          src="{{ section.settings.image | img_url: '1500x' }}"
+          src="{{ section.settings.image | image_url: width: 1500 }}"
           loading="lazy"
           alt="{{ section.settings.image.alt | escape }}"
           width="{{ section.settings.image.width }}"

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -40,7 +40,7 @@
             {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
             {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
             {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
-            {{ section.settings.image | image_url: width: 'master' }}"
+            {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
           sizes="100vw"
           src="{{ section.settings.image | image_url: width: 1500 }}"
           loading="lazy"

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -434,9 +434,9 @@
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
     {% if seo_media -%}
-      {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
+      {%- assign media_size = seo_media.preview_image.width -%}
       "image": [
-        {{ seo_media | img_url: media_size | prepend: "https:" | json }}
+        {{ seo_media | image_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif %}
     "description": {{ product.description | strip_html | json }},

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -436,7 +436,7 @@
     {% if seo_media -%}
       {%- assign media_size = seo_media.preview_image.width -%}
       "image": [
-        {{ seo_media | image_url: media_size | prepend: "https:" | json }}
+        {{ seo_media | image_url: width: media_size | prepend: "https:" | json }}
       ],
     {%- endif %}
     "description": {{ product.description | strip_html | json }},

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -59,7 +59,7 @@
                     {%- if block.settings.image != blank -%}
                       {%- assign image_size = block.settings.image_width -%}
                       <img
-                        srcset= "{{ block.settings.image | image_url: width: image_size }}, {{ block.settings.image | image_url: image_size, scale: 2 }} 2x"
+                        srcset= "{{ block.settings.image | image_url: width: image_size }}, {{ block.settings.image | image_url: width: image_size, scale: 2 }} 2x"
                         src="{{ block.settings.image | image_url: width: 400 }}"
                         alt="{{ block.settings.image.alt | escape }}"
                         loading="lazy"

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -57,10 +57,10 @@
 
                   <div class="footer-block__details-content footer-block-image {{ block.settings.alignment }}">
                     {%- if block.settings.image != blank -%}
-                      {%- assign image_size = block.settings.image_width | append: 'x' -%}
+                      {%- assign image_size = block.settings.image_width -%}
                       <img
-                        srcset= "{{ block.settings.image | img_url: image_size }}, {{ block.settings.image | img_url: image_size, scale: 2 }} 2x"
-                        src="{{ block.settings.image | img_url: '400x' }}"
+                        srcset= "{{ block.settings.image | image_url: width: image_size }}, {{ block.settings.image | image_url: image_size, scale: 2 }} 2x"
+                        src="{{ block.settings.image | image_url: width: 400 }}"
                         alt="{{ block.settings.image.alt | escape }}"
                         loading="lazy"
                         width="{{ block.settings.image.width }}"

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -90,7 +90,7 @@
     "name": {{ shop.name | json }},
     {% if section.settings.logo %}
       {% assign image_size = section.settings.logo.width %}
-      "logo": {{ section.settings.logo | image_url: image_size | prepend: "https:" | json }},
+      "logo": {{ section.settings.logo | image_url: width: image_size | prepend: "https:" | json }},
     {% endif %}
     "sameAs": [
       {{ settings.social_twitter_link | json }},

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -89,8 +89,8 @@
     "@type": "Organization",
     "name": {{ shop.name | json }},
     {% if section.settings.logo %}
-      {% assign image_size = section.settings.logo.width | append: 'x' %}
-      "logo": {{ section.settings.logo | img_url: image_size | prepend: "https:" | json }},
+      {% assign image_size = section.settings.logo.width %}
+      "logo": {{ section.settings.logo | image_url: image_size | prepend: "https:" | json }},
     {% endif %}
     "sameAs": [
       {{ settings.social_twitter_link | json }},

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -33,16 +33,16 @@
   {%- if section.settings.image != blank -%}
     <div class="banner__media media{% if section.settings.image == blank and section.settings.image_2 == blank %} placeholder{% endif %}{% if section.settings.image_2 != blank %} banner__media-half{% endif %}">
       <img
-        srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | image_url: width: 375 }},{%- endif -%}
-          {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
-          {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
-          {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | image_url: width: 1100 }},{%- endif -%}
-          {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-          {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | image_url: width: 1780 }},{%- endif -%}
-          {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
-          {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
-          {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
-          {{ section.settings.image | image_url: 'master' }}"
+        srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | image_url: width: 375 }} 375w,{%- endif -%}
+          {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }} 550w,{%- endif -%}
+          {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }} 750w,{%- endif -%}
+          {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | image_url: width: 1100 }} 1100w,{%- endif -%}
+          {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }} 1500w,{%- endif -%}
+          {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | image_url: width: 1780 }} 1780w,{%- endif -%}
+          {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }} 2000w,{%- endif -%}
+          {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }} 3000w,{%- endif -%}
+          {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }} 3840w,{%- endif -%}
+          {{ section.settings.image | image_url }} {{ section.settings.image.width }}w"
         sizes="{% if section.settings.image_2 != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image_2 != blank %}50vw{% else %}100vw{% endif %}"
         src="{{ section.settings.image | image_url: width: 1500 }}"
         loading="lazy"
@@ -60,15 +60,15 @@
   {%- if section.settings.image_2 != blank -%}
     <div class="banner__media media{% if section.settings.image != blank %} banner__media-half{% endif %}">
       <img
-        srcset="{%- if section.settings.image_2.width >= 375 -%}{{ section.settings.image_2 | image_url: width: 375 }}{%- endif -%}
-          {%- if section.settings.image_2.width >= 750 -%}{{ section.settings.image_2 | image_url: width: 750 }},{%- endif -%}
-          {%- if section.settings.image_2.width >= 1100 -%}{{ section.settings.image_2 | image_url: width: 1100 }},{%- endif -%}
-          {%- if section.settings.image_2.width >= 1500 -%}{{ section.settings.image_2 | image_url: width: 1500 }},{%- endif -%}
-          {%- if section.settings.image_2.width >= 1780 -%}{{ section.settings.image_2 | image_url: width: 1780 }},{%- endif -%}
-          {%- if section.settings.image_2.width >= 2000 -%}{{ section.settings.image_2 | image_url: width: 2000 }},{%- endif -%}
-          {%- if section.settings.image_2.width >= 3000 -%}{{ section.settings.image_2 | image_url: width: 3000 }},{%- endif -%}
-          {%- if section.settings.image_2.width >= 3840 -%}{{ section.settings.image_2 | image_url: width: 3840 }},{%- endif -%}
-          {{ section.settings.image_2 | image_url: 'master' }}"
+        srcset="{%- if section.settings.image_2.width >= 375 -%}{{ section.settings.image_2 | image_url: width: 375 }} 375w,{%- endif -%}
+          {%- if section.settings.image_2.width >= 750 -%}{{ section.settings.image_2 | image_url: width: 750 }} 750w,{%- endif -%}
+          {%- if section.settings.image_2.width >= 1100 -%}{{ section.settings.image_2 | image_url: width: 1100 }} 1100w,{%- endif -%}
+          {%- if section.settings.image_2.width >= 1500 -%}{{ section.settings.image_2 | image_url: width: 1500 }} 1500w,{%- endif -%}
+          {%- if section.settings.image_2.width >= 1780 -%}{{ section.settings.image_2 | image_url: width: 1780 }} 1780w,{%- endif -%}
+          {%- if section.settings.image_2.width >= 2000 -%}{{ section.settings.image_2 | image_url: width: 2000 }} 2000w,{%- endif -%}
+          {%- if section.settings.image_2.width >= 3000 -%}{{ section.settings.image_2 | image_url: width: 3000 }} 3000w,{%- endif -%}
+          {%- if section.settings.image_2.width >= 3840 -%}{{ section.settings.image_2 | image_url: width: 3840 }} 3840w,{%- endif -%}
+          {{ section.settings.image_2 | image_url }} {{ section.settings.image_2 }}w"
         sizes="{% if section.settings.image != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image != blank %}50vw{% else %}100vw{% endif %}"
         src="{{ section.settings.image_2 | image_url: width: 1500 }}"
         loading="lazy"

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -42,7 +42,7 @@
           {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
           {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
           {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
-          {{ section.settings.image | image_url: width: 'master' }}"
+          {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
         sizes="{% if section.settings.image_2 != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image_2 != blank %}50vw{% else %}100vw{% endif %}"
         src="{{ section.settings.image | image_url: width: 1500 }}"
         loading="lazy"
@@ -68,7 +68,7 @@
           {%- if section.settings.image_2.width >= 2000 -%}{{ section.settings.image_2 | image_url: width: 2000 }},{%- endif -%}
           {%- if section.settings.image_2.width >= 3000 -%}{{ section.settings.image_2 | image_url: width: 3000 }},{%- endif -%}
           {%- if section.settings.image_2.width >= 3840 -%}{{ section.settings.image_2 | image_url: width: 3840 }},{%- endif -%}
-          {{ section.settings.image_2 | image_url: width: 'master' }}"
+          {{ section.settings.image_2 | image_url: height: 'master', width: section.settings.image_2.width }}"
         sizes="{% if section.settings.image != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image != blank %}50vw{% else %}100vw{% endif %}"
         src="{{ section.settings.image_2 | image_url: width: 1500 }}"
         loading="lazy"

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -33,18 +33,18 @@
   {%- if section.settings.image != blank -%}
     <div class="banner__media media{% if section.settings.image == blank and section.settings.image_2 == blank %} placeholder{% endif %}{% if section.settings.image_2 != blank %} banner__media-half{% endif %}">
       <img
-        srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | img_url: '375x' }} 375w,{%- endif -%}
-          {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | img_url: '550x' }} 550w,{%- endif -%}
-          {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | img_url: '750x' }} 750w,{%- endif -%}
-          {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | img_url: '1100x' }} 1100w,{%- endif -%}
-          {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | img_url: '1500x' }} 1500w,{%- endif -%}
-          {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | img_url: '1780x' }} 1780w,{%- endif -%}
-          {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | img_url: '2000x' }} 2000w,{%- endif -%}
-          {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | img_url: '3000x' }} 3000w,{%- endif -%}
-          {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | img_url: '3840x' }} 3840w,{%- endif -%}
-          {{ section.settings.image | img_url: 'master' }} {{ section.settings.image.width }}w"
+        srcset="{%- if section.settings.image.width >= 375 -%}{{ section.settings.image | image_url: width: 375 }},{%- endif -%}
+          {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
+          {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
+          {%- if section.settings.image.width >= 1100 -%}{{ section.settings.image | image_url: width: 1100 }},{%- endif -%}
+          {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
+          {%- if section.settings.image.width >= 1780 -%}{{ section.settings.image | image_url: width: 1780 }},{%- endif -%}
+          {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
+          {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
+          {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
+          {{ section.settings.image | image_url: width: 'master' }}"
         sizes="{% if section.settings.image_2 != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image_2 != blank %}50vw{% else %}100vw{% endif %}"
-        src="{{ section.settings.image | img_url: '1500x' }}"
+        src="{{ section.settings.image | image_url: width: 1500 }}"
         loading="lazy"
         alt="{{ section.settings.image.alt | escape }}"
         width="{{ section.settings.image.width }}"
@@ -60,17 +60,17 @@
   {%- if section.settings.image_2 != blank -%}
     <div class="banner__media media{% if section.settings.image != blank %} banner__media-half{% endif %}">
       <img
-        srcset="{%- if section.settings.image_2.width >= 375 -%}{{ section.settings.image_2 | img_url: '375x' }} 375w,{%- endif -%}
-          {%- if section.settings.image_2.width >= 750 -%}{{ section.settings.image_2 | img_url: '750x' }} 750w,{%- endif -%}
-          {%- if section.settings.image_2.width >= 1100 -%}{{ section.settings.image_2 | img_url: '1100x' }} 1100w,{%- endif -%}
-          {%- if section.settings.image_2.width >= 1500 -%}{{ section.settings.image_2 | img_url: '1500x' }} 1500w,{%- endif -%}
-          {%- if section.settings.image_2.width >= 1780 -%}{{ section.settings.image_2 | img_url: '1780x' }} 1780w,{%- endif -%}
-          {%- if section.settings.image_2.width >= 2000 -%}{{ section.settings.image_2 | img_url: '2000x' }} 2000w,{%- endif -%}
-          {%- if section.settings.image_2.width >= 3000 -%}{{ section.settings.image_2 | img_url: '3000x' }} 3000w,{%- endif -%}
-          {%- if section.settings.image_2.width >= 3840 -%}{{ section.settings.image_2 | img_url: '3840x' }} 3840w,{%- endif -%}
-          {{ section.settings.image_2 | img_url: 'master' }} {{ section.settings.image_2.width }}w"
+        srcset="{%- if section.settings.image_2.width >= 375 -%}{{ section.settings.image_2 | image_url: width: 375 }}{%- endif -%}
+          {%- if section.settings.image_2.width >= 750 -%}{{ section.settings.image_2 | image_url: width: 750 }},{%- endif -%}
+          {%- if section.settings.image_2.width >= 1100 -%}{{ section.settings.image_2 | image_url: width: 1100 }},{%- endif -%}
+          {%- if section.settings.image_2.width >= 1500 -%}{{ section.settings.image_2 | image_url: width: 1500 }},{%- endif -%}
+          {%- if section.settings.image_2.width >= 1780 -%}{{ section.settings.image_2 | image_url: width: 1780 }},{%- endif -%}
+          {%- if section.settings.image_2.width >= 2000 -%}{{ section.settings.image_2 | image_url: width: 2000 }},{%- endif -%}
+          {%- if section.settings.image_2.width >= 3000 -%}{{ section.settings.image_2 | image_url: width: 3000 }},{%- endif -%}
+          {%- if section.settings.image_2.width >= 3840 -%}{{ section.settings.image_2 | image_url: width: 3840 }},{%- endif -%}
+          {{ section.settings.image_2 | image_url: width: 'master' }}"
         sizes="{% if section.settings.image != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image != blank %}50vw{% else %}100vw{% endif %}"
-        src="{{ section.settings.image_2 | img_url: '1500x' }}"
+        src="{{ section.settings.image_2 | image_url: width: 1500 }}"
         loading="lazy"
         alt="{{ section.settings.image_2.alt | escape }}"
         width="{{ section.settings.image_2.width }}"

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -42,7 +42,7 @@
           {%- if section.settings.image.width >= 2000 -%}{{ section.settings.image | image_url: width: 2000 }},{%- endif -%}
           {%- if section.settings.image.width >= 3000 -%}{{ section.settings.image | image_url: width: 3000 }},{%- endif -%}
           {%- if section.settings.image.width >= 3840 -%}{{ section.settings.image | image_url: width: 3840 }},{%- endif -%}
-          {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
+          {{ section.settings.image | image_url: 'master' }}"
         sizes="{% if section.settings.image_2 != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image_2 != blank %}50vw{% else %}100vw{% endif %}"
         src="{{ section.settings.image | image_url: width: 1500 }}"
         loading="lazy"
@@ -68,7 +68,7 @@
           {%- if section.settings.image_2.width >= 2000 -%}{{ section.settings.image_2 | image_url: width: 2000 }},{%- endif -%}
           {%- if section.settings.image_2.width >= 3000 -%}{{ section.settings.image_2 | image_url: width: 3000 }},{%- endif -%}
           {%- if section.settings.image_2.width >= 3840 -%}{{ section.settings.image_2 | image_url: width: 3840 }},{%- endif -%}
-          {{ section.settings.image_2 | image_url: height: 'master', width: section.settings.image_2.width }}"
+          {{ section.settings.image_2 | image_url: 'master' }}"
         sizes="{% if section.settings.image != blank and section.settings.stack_images_on_mobile %}(min-width: 750px) 50vw, 100vw{% elsif section.settings.image != blank %}50vw{% else %}100vw{% endif %}"
         src="{{ section.settings.image_2 | image_url: width: 1500 }}"
         loading="lazy"

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -22,13 +22,13 @@
       >
         {%- if section.settings.image != blank -%}
           <img
-            srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: width: 165 }},{%- endif -%}
-              {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: width: 360 }},{%- endif -%}
-              {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: width: 535 }},{%- endif -%}
-              {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
-              {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
-              {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-              {{ section.settings.image | image_url: 'master' }}"
+            srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: width: 165 }} 165w,{%- endif -%}
+              {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: width: 360 }} 360w,{%- endif -%}
+              {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: width: 535 }} 535w,{%- endif -%}
+              {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }} 750w,{%- endif -%}
+              {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }} 1070w,{%- endif -%}
+              {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }} 1500w,{%- endif -%}
+              {{ section.settings.image | image_url }} {{ section.settings.image.width }}w"
             src="{{ section.settings.image | image_url: width: 1500 }}"
             sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
             alt="{{ section.settings.image.alt | escape }}"

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -28,7 +28,7 @@
               {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
               {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
               {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-              {{ section.settings.image | image_url: width: 'master' }}"
+              {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
             src="{{ section.settings.image | image_url: width: 1500 }}"
             sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
             alt="{{ section.settings.image.alt | escape }}"

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -28,7 +28,7 @@
               {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
               {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
               {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
-              {{ section.settings.image | image_url: height: 'master', width: section.settings.image.width }}"
+              {{ section.settings.image | image_url: 'master' }}"
             src="{{ section.settings.image | image_url: width: 1500 }}"
             sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
             alt="{{ section.settings.image.alt | escape }}"

--- a/sections/image-with-text.liquid
+++ b/sections/image-with-text.liquid
@@ -22,14 +22,14 @@
       >
         {%- if section.settings.image != blank -%}
           <img
-            srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | img_url: '165x' }} 165w,{%- endif -%}
-              {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | img_url: '360x' }} 360w,{%- endif -%}
-              {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | img_url: '535x' }} 535w,{%- endif -%}
-              {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | img_url: '750x' }} 750w,{%- endif -%}
-              {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | img_url: '1070x' }} 1070w,{%- endif -%}
-              {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | img_url: '1500x' }} 1500w,{%- endif -%}
-              {{ section.settings.image | img_url: 'master' }} {{ section.settings.image.width }}w"
-            src="{{ section.settings.image | img_url: '1500x' }}"
+            srcset="{%- if section.settings.image.width >= 165 -%}{{ section.settings.image | image_url: width: 165 }},{%- endif -%}
+              {%- if section.settings.image.width >= 360 -%}{{ section.settings.image | image_url: width: 360 }},{%- endif -%}
+              {%- if section.settings.image.width >= 535 -%}{{ section.settings.image | image_url: width: 535 }},{%- endif -%}
+              {%- if section.settings.image.width >= 750 -%}{{ section.settings.image | image_url: width: 750 }},{%- endif -%}
+              {%- if section.settings.image.width >= 1070 -%}{{ section.settings.image | image_url: width: 1070 }},{%- endif -%}
+              {%- if section.settings.image.width >= 1500 -%}{{ section.settings.image | image_url: width: 1500 }},{%- endif -%}
+              {{ section.settings.image | image_url: width: 'master' }}"
+            src="{{ section.settings.image | image_url: width: 1500 }}"
             sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
             alt="{{ section.settings.image.alt | escape }}"
             loading="lazy"

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -21,7 +21,7 @@
                   {% if article.image.width >= 1500 %}{{ article.image | image_url: width: 1500 }},{% endif %}
                   {% if article.image.width >= 2200 %}{{ article.image | image_url: width: 2200 }},{% endif %}
                   {% if article.image.width >= 3000 %}{{ article.image | image_url: width: 3000 }},{% endif %}
-                  {{ article.image | image_url: height: 'master', width: article.image.width }}"
+                  {{ article.image | image_url: 'master' }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw"
                 src="{{ article.image | image_url: width: 1100 }}"
                 loading="lazy"

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -21,7 +21,7 @@
                   {% if article.image.width >= 1500 %}{{ article.image | image_url: width: 1500 }},{% endif %}
                   {% if article.image.width >= 2200 %}{{ article.image | image_url: width: 2200 }},{% endif %}
                   {% if article.image.width >= 3000 %}{{ article.image | image_url: width: 3000 }},{% endif %}
-                  {{ article.image | image_url: width: 'master' }}"
+                  {{ article.image | image_url: height: 'master', width: article.image.width }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw"
                 src="{{ article.image | image_url: width: 1100 }}"
                 loading="lazy"

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -15,15 +15,15 @@
               {% if block.settings.image_height == 'adapt' and article.image %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}
             >
               <img
-                srcset="{% if article.image.width >= 350 %}{{ article.image | img_url: '350x' }} 350w,{% endif %}
-                  {% if article.image.width >= 750 %}{{ article.image | img_url: '750x' }} 750w,{% endif %}
-                  {% if article.image.width >= 1100 %}{{ article.image | img_url: '1100x' }} 1100w,{% endif %}
-                  {% if article.image.width >= 1500 %}{{ article.image | img_url: '1500x' }} 1500w,{% endif %}
-                  {% if article.image.width >= 2200 %}{{ article.image | img_url: '2200x' }} 2200w,{% endif %}
-                  {% if article.image.width >= 3000 %}{{ article.image | img_url: '3000x' }} 3000w,{% endif %}
-                  {{ article.image | img_url: 'master' }} {{ article.image.width }}w"
+                srcset="{% if article.image.width >= 350 %}{{ article.image | image_url: width: 350 }},{% endif %}
+                  {% if article.image.width >= 750 %}{{ article.image | image_url: width: 750 }},{% endif %}
+                  {% if article.image.width >= 1100 %}{{ article.image | image_url: width: 1100 }},{% endif %}
+                  {% if article.image.width >= 1500 %}{{ article.image | image_url: width: 1500 }},{% endif %}
+                  {% if article.image.width >= 2200 %}{{ article.image | image_url: width: 2200 }},{% endif %}
+                  {% if article.image.width >= 3000 %}{{ article.image | image_url: width: 3000 }},{% endif %}
+                  {{ article.image | image_url: width: 'master' }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw"
-                src="{{ article.image | img_url: '1100x' }}"
+                src="{{ article.image | image_url: width: 1100 }}"
                 loading="lazy"
                 width="{{ article.image.width }}"
                 height="{{ article.image.height }}"
@@ -258,9 +258,9 @@
       "description": {{ article.excerpt | strip_html | json }},
     {% endif %}
     {% if article.image %}
-      {% assign image_size = article.image.width | append: 'x' %}
+      {% assign image_size = article.image.width %}
       "image": [
-        {{ article | img_url: image_size | prepend: "https:" | json }}
+        {{ article | image_url: image_size | prepend: "https:" | json }}
       ],
     {% endif %}
     "datePublished": {{ article.published_at | date: '%Y-%m-%dT%H:%M:%SZ' | json }},
@@ -272,11 +272,11 @@
     "publisher": {
       "@type": "Organization",
       {% if settings.share_image %}
-        {% assign image_size = settings.share_image.width | append: 'x' %}
+        {% assign image_size = settings.share_image.width %}
         "logo": {
           "@type": "ImageObject",
           "height": {{ settings.share_image.height | json }},
-          "url": {{ settings.share_image | img_url: image_size | prepend: "https:" | json }},
+          "url": {{ settings.share_image | image_url: image_size | prepend: "https:" | json }},
           "width": {{ settings.share_image.width | json }}
         },
       {% endif %}

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -260,7 +260,7 @@
     {% if article.image %}
       {% assign image_size = article.image.width %}
       "image": [
-        {{ article | image_url: image_size | prepend: "https:" | json }}
+        {{ article | image_url: width: image_size | prepend: "https:" | json }}
       ],
     {% endif %}
     "datePublished": {{ article.published_at | date: '%Y-%m-%dT%H:%M:%SZ' | json }},
@@ -276,7 +276,7 @@
         "logo": {
           "@type": "ImageObject",
           "height": {{ settings.share_image.height | json }},
-          "url": {{ settings.share_image | image_url: image_size | prepend: "https:" | json }},
+          "url": {{ settings.share_image | image_url: width: image_size | prepend: "https:" | json }},
           "width": {{ settings.share_image.width | json }}
         },
       {% endif %}

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -15,13 +15,13 @@
               {% if block.settings.image_height == 'adapt' and article.image %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}
             >
               <img
-                srcset="{% if article.image.width >= 350 %}{{ article.image | image_url: width: 350 }},{% endif %}
-                  {% if article.image.width >= 750 %}{{ article.image | image_url: width: 750 }},{% endif %}
-                  {% if article.image.width >= 1100 %}{{ article.image | image_url: width: 1100 }},{% endif %}
-                  {% if article.image.width >= 1500 %}{{ article.image | image_url: width: 1500 }},{% endif %}
-                  {% if article.image.width >= 2200 %}{{ article.image | image_url: width: 2200 }},{% endif %}
-                  {% if article.image.width >= 3000 %}{{ article.image | image_url: width: 3000 }},{% endif %}
-                  {{ article.image | image_url: 'master' }}"
+                srcset="{% if article.image.width >= 350 %}{{ article.image | image_url: width: 350 }} 350w,{% endif %}
+                  {% if article.image.width >= 750 %}{{ article.image | image_url: width: 750 }} 750w,{% endif %}
+                  {% if article.image.width >= 1100 %}{{ article.image | image_url: width: 1100 }} 1100w,{% endif %}
+                  {% if article.image.width >= 1500 %}{{ article.image | image_url: width: 1500 }} 1500w,{% endif %}
+                  {% if article.image.width >= 2200 %}{{ article.image | image_url: width: 2200 }} 2200w,{% endif %}
+                  {% if article.image.width >= 3000 %}{{ article.image | image_url: width: 3000 }} 3000w,{% endif %}
+                  {{ article.image | image_url }} {{ article.image.width }}w"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw"
                 src="{{ article.image | image_url: width: 1100 }}"
                 loading="lazy"

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -30,7 +30,7 @@
             {%- if collection.image.width >= 750 -%}{{ collection.image | image_url: width: 750 }},{%- endif -%}
             {%- if collection.image.width >= 1070 -%}{{ collection.image | image_url: width: 1070 }},{%- endif -%}
             {%- if collection.image.width >= 1500 -%}{{ collection.image | image_url: width: 1500 }},{%- endif -%}
-            {{ collection.image | image_url: height: 'master', width: collection.image.width }}"
+            {{ collection.image | image_url: 'master' }}"
           src="{{ collection.image | image_url: width: 750 }}"
           sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc(50vw - 130px), calc(50vw - 55px)"
           alt="{{ collection.title | escape }}"

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -24,13 +24,13 @@
     {%- if section.settings.show_collection_image and collection.image -%}
       <div class="collection-hero__image-container media gradient">
         <img
-          srcset="{%- if collection.image.width >= 165 -%}{{ collection.image | image_url: width: 165 }},{%- endif -%}
-            {%- if collection.image.width >= 360 -%}{{ collection.image | image_url: width: 360 }},{%- endif -%}
-            {%- if collection.image.width >= 535 -%}{{ collection.image | image_url: width: 535 }},{%- endif -%}
-            {%- if collection.image.width >= 750 -%}{{ collection.image | image_url: width: 750 }},{%- endif -%}
-            {%- if collection.image.width >= 1070 -%}{{ collection.image | image_url: width: 1070 }},{%- endif -%}
-            {%- if collection.image.width >= 1500 -%}{{ collection.image | image_url: width: 1500 }},{%- endif -%}
-            {{ collection.image | image_url: 'master' }}"
+          srcset="{%- if collection.image.width >= 165 -%}{{ collection.image | image_url: width: 165 }} 165w,{%- endif -%}
+            {%- if collection.image.width >= 360 -%}{{ collection.image | image_url: width: 360 }} 360w,{%- endif -%}
+            {%- if collection.image.width >= 535 -%}{{ collection.image | image_url: width: 535 }} 550w,{%- endif -%}
+            {%- if collection.image.width >= 750 -%}{{ collection.image | image_url: width: 750 }} 750w,{%- endif -%}
+            {%- if collection.image.width >= 1070 -%}{{ collection.image | image_url: width: 1070 }} 1070w,{%- endif -%}
+            {%- if collection.image.width >= 1500 -%}{{ collection.image | image_url: width: 1500 }} 1500w,{%- endif -%}
+            {{ collection.image | image_url }} {{ collection.image.width }}w"
           src="{{ collection.image | image_url: width: 750 }}"
           sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc(50vw - 130px), calc(50vw - 55px)"
           alt="{{ collection.title | escape }}"

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -30,7 +30,7 @@
             {%- if collection.image.width >= 750 -%}{{ collection.image | image_url: width: 750 }},{%- endif -%}
             {%- if collection.image.width >= 1070 -%}{{ collection.image | image_url: width: 1070 }},{%- endif -%}
             {%- if collection.image.width >= 1500 -%}{{ collection.image | image_url: width: 1500 }},{%- endif -%}
-            {{ collection.image | image_url: width: 'master' }}"
+            {{ collection.image | image_url: height: 'master', width: collection.image.width }}"
           src="{{ collection.image | image_url: width: 750 }}"
           sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc(50vw - 130px), calc(50vw - 55px)"
           alt="{{ collection.title | escape }}"

--- a/sections/main-collection-banner.liquid
+++ b/sections/main-collection-banner.liquid
@@ -24,14 +24,14 @@
     {%- if section.settings.show_collection_image and collection.image -%}
       <div class="collection-hero__image-container media gradient">
         <img
-          srcset="{%- if collection.image.width >= 165 -%}{{ collection.image | img_url: '165x' }} 165w,{%- endif -%}
-            {%- if collection.image.width >= 360 -%}{{ collection.image | img_url: '360x' }} 360w,{%- endif -%}
-            {%- if collection.image.width >= 535 -%}{{ collection.image | img_url: '535x' }} 535w,{%- endif -%}
-            {%- if collection.image.width >= 750 -%}{{ collection.image | img_url: '750x' }} 750w,{%- endif -%}
-            {%- if collection.image.width >= 1070 -%}{{ collection.image | img_url: '1070x' }} 1070w,{%- endif -%}
-            {%- if collection.image.width >= 1500 -%}{{ collection.image | img_url: '1500x' }} 1500w,{%- endif -%}
-            {{ collection.image | img_url: 'master' }} {{ collection.image.width }}w"
-          src="{{ collection.image | img_url: '750x' }}"
+          srcset="{%- if collection.image.width >= 165 -%}{{ collection.image | image_url: width: 165 }},{%- endif -%}
+            {%- if collection.image.width >= 360 -%}{{ collection.image | image_url: width: 360 }},{%- endif -%}
+            {%- if collection.image.width >= 535 -%}{{ collection.image | image_url: width: 535 }},{%- endif -%}
+            {%- if collection.image.width >= 750 -%}{{ collection.image | image_url: width: 750 }},{%- endif -%}
+            {%- if collection.image.width >= 1070 -%}{{ collection.image | image_url: width: 1070 }},{%- endif -%}
+            {%- if collection.image.width >= 1500 -%}{{ collection.image | image_url: width: 1500 }},{%- endif -%}
+            {{ collection.image | image_url: width: 'master' }}"
+          src="{{ collection.image | image_url: width: 750 }}"
           sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc(50vw - 130px), calc(50vw - 55px)"
           alt="{{ collection.title | escape }}"
           width="{{ collection.image.width }}"

--- a/sections/main-password-header.liquid
+++ b/sections/main-password-header.liquid
@@ -2,7 +2,7 @@
   <div class="password-header">
     {%- if section.settings.logo -%}
       <img
-        src="{{ section.settings.logo | image_url: 500 }}"
+        src="{{ section.settings.logo | image_url: width: 500 }}"
         class="password-logo"
         alt="{{ section.settings.logo.alt | default: shop.name | escape }}"
         style="max-width: {{ section.settings.logo_max_width }}px"

--- a/sections/main-password-header.liquid
+++ b/sections/main-password-header.liquid
@@ -2,7 +2,7 @@
   <div class="password-header">
     {%- if section.settings.logo -%}
       <img
-        src="{{ section.settings.logo | img_url: '500x500' }}"
+        src="{{ section.settings.logo | image_url: 500 }}"
         class="password-logo"
         alt="{{ section.settings.logo.alt | default: shop.name | escape }}"
         style="max-width: {{ section.settings.logo_max_width }}px"

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -460,9 +460,9 @@
     "name": {{ product.title | json }},
     "url": {{ shop.url | append: product.url | json }},
     {% if seo_media -%}
-      {%- assign media_size = seo_media.preview_image.width | append: 'x' -%}
+      {%- assign media_size = seo_media.preview_image.width -%}
       "image": [
-        {{ seo_media | img_url: media_size | prepend: "https:" | json }}
+        {{ seo_media | image_url: media_size | prepend: "https:" | json }}
       ],
     {%- endif %}
     "description": {{ product.description | strip_html | json }},

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -462,7 +462,7 @@
     {% if seo_media -%}
       {%- assign media_size = seo_media.preview_image.width -%}
       "image": [
-        {{ seo_media | image_url: media_size | prepend: "https:" | json }}
+        {{ seo_media | image_url: width: media_size | prepend: "https:" | json }}
       ],
     {%- endif %}
     "description": {{ product.description | strip_html | json }},

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -59,7 +59,7 @@
                         {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
                         {%- if block.settings.image.width >= 710 -%}{{ block.settings.image | image_url: width: 710 }},{%- endif -%}
                         {%- if block.settings.image.width >= 1420 -%}{{ block.settings.image | image_url: width: 1420 }},{%- endif -%}
-                        {{ block.settings.image | image_url: height: 'master', width: block.settings.image.width }}"
+                        {{ block.settings.image | image_url: 'master' }}"
                       src="{{ block.settings.image | image_url: width: 550 }}"
                       sizes="(min-width: 990px) {% if section.blocks.size <= 2 %}710px{% else %}550px{% endif %},
                         (min-width: 750px) {% if section.blocks.size == 1 %}710px{% else %}550px{% endif %},

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -59,7 +59,7 @@
                         {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
                         {%- if block.settings.image.width >= 710 -%}{{ block.settings.image | image_url: width: 710 }},{%- endif -%}
                         {%- if block.settings.image.width >= 1420 -%}{{ block.settings.image | image_url: width: 1420 }},{%- endif -%}
-                        {{ block.settings.image | image_url: width: 'master' }}"
+                        {{ block.settings.image | image_url: height: 'master', width: block.settings.image.width }}"
                       src="{{ block.settings.image | image_url: width: 550 }}"
                       sizes="(min-width: 990px) {% if section.blocks.size <= 2 %}710px{% else %}550px{% endif %},
                         (min-width: 750px) {% if section.blocks.size == 1 %}710px{% else %}550px{% endif %},

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -55,12 +55,12 @@
                     {% endif %}>
                     <img
                       class="multicolumn-card__image"
-                      srcset="{%- if block.settings.image.width >= 275 -%}{{ block.settings.image | img_url: '275x' }} 275w,{%- endif -%}
-                        {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | img_url: '550x' }} 550w,{%- endif -%}
-                        {%- if block.settings.image.width >= 710 -%}{{ block.settings.image | img_url: '710x' }} 710w,{%- endif -%}
-                        {%- if block.settings.image.width >= 1420 -%}{{ block.settings.image | img_url: '1420x' }} 1420w,{%- endif -%}
-                        {{ block.settings.image | img_url: 'master' }} {{ block.settings.image.width }}w"
-                      src="{{ block.settings.image | img_url: '550x' }}"
+                      srcset="{%- if block.settings.image.width >= 275 -%}{{ block.settings.image | image_url: width: 275 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 710 -%}{{ block.settings.image | image_url: width: 710 }},{%- endif -%}
+                        {%- if block.settings.image.width >= 1420 -%}{{ block.settings.image | image_url: width: 1420 }},{%- endif -%}
+                        {{ block.settings.image | image_url: width: 'master' }}"
+                      src="{{ block.settings.image | image_url: width: 550 }}"
                       sizes="(min-width: 990px) {% if section.blocks.size <= 2 %}710px{% else %}550px{% endif %},
                         (min-width: 750px) {% if section.blocks.size == 1 %}710px{% else %}550px{% endif %},
                         calc(100vw - 30px)"

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -55,11 +55,11 @@
                     {% endif %}>
                     <img
                       class="multicolumn-card__image"
-                      srcset="{%- if block.settings.image.width >= 275 -%}{{ block.settings.image | image_url: width: 275 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 710 -%}{{ block.settings.image | image_url: width: 710 }},{%- endif -%}
-                        {%- if block.settings.image.width >= 1420 -%}{{ block.settings.image | image_url: width: 1420 }},{%- endif -%}
-                        {{ block.settings.image | image_url: 'master' }}"
+                      srcset="{%- if block.settings.image.width >= 275 -%}{{ block.settings.image | image_url: width: 275 }} 275w,{%- endif -%}
+                        {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }} 550w,{%- endif -%}
+                        {%- if block.settings.image.width >= 710 -%}{{ block.settings.image | image_url: width: 710 }} 710w,{%- endif -%}
+                        {%- if block.settings.image.width >= 1420 -%}{{ block.settings.image | image_url: width: 1420 }} 1420w,{%- endif -%}
+                        {{ block.settings.image | image_url }} {{ block.settings.image.width }}w"
                       src="{{ block.settings.image | image_url: width: 550 }}"
                       sizes="(min-width: 990px) {% if section.blocks.size <= 2 %}710px{% else %}550px{% endif %},
                         (min-width: 750px) {% if section.blocks.size == 1 %}710px{% else %}550px{% endif %},

--- a/sections/predictive-search.liquid
+++ b/sections/predictive-search.liquid
@@ -15,7 +15,7 @@
           <a href="{{ product.url }}" class="predictive-search__item predictive-search__item--link link link--text" tabindex="-1">
             {%- if product.featured_media != blank -%}
               <img class="predictive-search__image"
-                src="{{ product.featured_media | img_url: '150x' }}"
+                src="{{ product.featured_media | image_url: 150 }}"
                 alt="{{ product.featured_media.alt }}"
                 width="50"
                 height="{{ 50 | divided_by: product.featured_media.preview_image.aspect_ratio }}"

--- a/sections/predictive-search.liquid
+++ b/sections/predictive-search.liquid
@@ -15,7 +15,7 @@
           <a href="{{ product.url }}" class="predictive-search__item predictive-search__item--link link link--text" tabindex="-1">
             {%- if product.featured_media != blank -%}
               <img class="predictive-search__image"
-                src="{{ product.featured_media | image_url: 150 }}"
+                src="{{ product.featured_media | image_url: width: 150 }}"
                 alt="{{ product.featured_media.alt }}"
                 width="50"
                 height="{{ 50 | divided_by: product.featured_media.preview_image.aspect_ratio }}"

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -51,16 +51,16 @@
         <div class="slideshow__media banner__media media{% if block.settings.image == blank %} placeholder{% endif %}">
           {%- if block.settings.image -%}
             <img
-              srcset="{%- if block.settings.image.width >= 375 -%}{{ block.settings.image | image_url: width: 375 }},{%- endif -%}
-              {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
-              {%- if block.settings.image.width >= 750 -%}{{ block.settings.image | image_url: width: 750 }},{%- endif -%}
-              {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | image_url: width: 1100 }},{%- endif -%}
-              {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }},{%- endif -%}
-              {%- if block.settings.image.width >= 1780 -%}{{ block.settings.image | image_url: width: 1780 }},{%- endif -%}
-              {%- if block.settings.image.width >= 2000 -%}{{ block.settings.image | image_url: width: 2000 }},{%- endif -%}
-              {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
-              {%- if block.settings.image.width >= 3840 -%}{{ block.settings.image | image_url: width: 3840 }},{%- endif -%}
-              {{ block.settings.image | image_url: 'master' }}"
+              srcset="{%- if block.settings.image.width >= 375 -%}{{ block.settings.image | image_url: width: 375 }} 375w,{%- endif -%}
+              {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }} 550w,{%- endif -%}
+              {%- if block.settings.image.width >= 750 -%}{{ block.settings.image | image_url: width: 750 }} 750w,{%- endif -%}
+              {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | image_url: width: 1100 }} 1100w,{%- endif -%}
+              {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }} 1500w,{%- endif -%}
+              {%- if block.settings.image.width >= 1780 -%}{{ block.settings.image | image_url: width: 1780 }} 1780w,{%- endif -%}
+              {%- if block.settings.image.width >= 2000 -%}{{ block.settings.image | image_url: width: 2000 }} 2000w,{%- endif -%}
+              {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }} 3000w,{%- endif -%}
+              {%- if block.settings.image.width >= 3840 -%}{{ block.settings.image | image_url: width: 3840 }} 3840w,{%- endif -%}
+              {{ block.settings.image | image_url }} {{ block.settings.image.width }}w"
               sizes="100vw"
               src="{{ block.settings.image | image_url: width: 1500 }}"
               loading="lazy"

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -60,7 +60,7 @@
               {%- if block.settings.image.width >= 2000 -%}{{ block.settings.image | image_url: width: 2000 }},{%- endif -%}
               {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
               {%- if block.settings.image.width >= 3840 -%}{{ block.settings.image | image_url: width: 3840 }},{%- endif -%}
-              {{ block.settings.image | image_url: height: 'master', width: block.settings.image.width }}"
+              {{ block.settings.image | image_url: 'master' }}"
               sizes="100vw"
               src="{{ block.settings.image | image_url: width: 1500 }}"
               loading="lazy"

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -51,18 +51,18 @@
         <div class="slideshow__media banner__media media{% if block.settings.image == blank %} placeholder{% endif %}">
           {%- if block.settings.image -%}
             <img
-              srcset="{%- if block.settings.image.width >= 375 -%}{{ block.settings.image | img_url: '375x' }} 375w,{%- endif -%}
-              {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | img_url: '550x' }} 550w,{%- endif -%}
-              {%- if block.settings.image.width >= 750 -%}{{ block.settings.image | img_url: '750x' }} 750w,{%- endif -%}
-              {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | img_url: '1100x' }} 1100w,{%- endif -%}
-              {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | img_url: '1500x' }} 1500w,{%- endif -%}
-              {%- if block.settings.image.width >= 1780 -%}{{ block.settings.image | img_url: '1780x' }} 1780w,{%- endif -%}
-              {%- if block.settings.image.width >= 2000 -%}{{ block.settings.image | img_url: '2000x' }} 2000w,{%- endif -%}
-              {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | img_url: '3000x' }} 3000w,{%- endif -%}
-              {%- if block.settings.image.width >= 3840 -%}{{ block.settings.image | img_url: '3840x' }} 3840w,{%- endif -%}
-              {{ block.settings.image | img_url: 'master' }} {{ block.settings.image.width }}w"
+              srcset="{%- if block.settings.image.width >= 375 -%}{{ block.settings.image | image_url: width: 375 }},{%- endif -%}
+              {%- if block.settings.image.width >= 550 -%}{{ block.settings.image | image_url: width: 550 }},{%- endif -%}
+              {%- if block.settings.image.width >= 750 -%}{{ block.settings.image | image_url: width: 750 }},{%- endif -%}
+              {%- if block.settings.image.width >= 1100 -%}{{ block.settings.image | image_url: width: 1100 }},{%- endif -%}
+              {%- if block.settings.image.width >= 1500 -%}{{ block.settings.image | image_url: width: 1500 }},{%- endif -%}
+              {%- if block.settings.image.width >= 1780 -%}{{ block.settings.image | image_url: width: 1780 }},{%- endif -%}
+              {%- if block.settings.image.width >= 2000 -%}{{ block.settings.image | image_url: width: 2000 }},{%- endif -%}
+              {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
+              {%- if block.settings.image.width >= 3840 -%}{{ block.settings.image | image_url: width: 3840 }},{%- endif -%}
+              {{ block.settings.image | image_url: width: 'master' }}"
               sizes="100vw"
-              src="{{ block.settings.image | img_url: '1500x' }}"
+              src="{{ block.settings.image | image_url: width: 1500 }}"
               loading="lazy"
               alt="{{ block.settings.image.alt | escape }}"
               width="{{ block.settings.image.width }}"

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -60,7 +60,7 @@
               {%- if block.settings.image.width >= 2000 -%}{{ block.settings.image | image_url: width: 2000 }},{%- endif -%}
               {%- if block.settings.image.width >= 3000 -%}{{ block.settings.image | image_url: width: 3000 }},{%- endif -%}
               {%- if block.settings.image.width >= 3840 -%}{{ block.settings.image | image_url: width: 3840 }},{%- endif -%}
-              {{ block.settings.image | image_url: width: 'master' }}"
+              {{ block.settings.image | image_url: height: 'master', width: block.settings.image.width }}"
               sizes="100vw"
               src="{{ block.settings.image | image_url: width: 1500 }}"
               loading="lazy"

--- a/sections/video.liquid
+++ b/sections/video.liquid
@@ -39,7 +39,7 @@
                 {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
                 {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
                 {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
-                {{ section.settings.cover_image | image_url: width: 'master' }} {{ section.settings.cover_image.width }}w"
+                {{ section.settings.cover_image | image_url: height: 'master', width: section.settings.cover_image.width }}"
               src="{{ section.settings.cover_image | image_url: width: 1920 }}"
               sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
               alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"
@@ -71,7 +71,7 @@
               {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
               {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
               {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
-              {{ section.settings.cover_image | image_url: width: 'master' }} {{ section.settings.cover_image.width }}w"
+              {{ section.settings.cover_image | image_url: height: 'master', width: section.settings.cover_image.width }}"
             src="{{ section.settings.cover_image | image_url: width: 1920 }}"
             sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
             alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"

--- a/sections/video.liquid
+++ b/sections/video.liquid
@@ -31,15 +31,15 @@
         <a href="{{ section.settings.video_url }}" class="video-section__poster media media--transparent media--landscape{% if section.settings.cover_image == blank %} video-section__placeholder{% endif %}">
           {%- if section.settings.cover_image != blank -%}
             <img
-              srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | image_url: width: 375 }},{%- endif -%}
-                {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | image_url: width: 750 }},{%- endif -%}
-                {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
-                {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
-                {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | image_url: width: 1780 }},{%- endif -%}
-                {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
-                {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-                {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
-                {{ section.settings.cover_image | image_url: 'master' }}"
+              srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | image_url: width: 375 }} 375w,{%- endif -%}
+                {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | image_url: width: 750 }} 750w,{%- endif -%}
+                {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | image_url: width: 1100 }} 1100w,{%- endif -%}
+                {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | image_url: width: 1500 }} 1500w,{%- endif -%}
+                {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | image_url: width: 1780 }} 1780w,{%- endif -%}
+                {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }} 2000w,{%- endif -%}
+                {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }} 3000w,{%- endif -%}
+                {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }} 3840w,{%- endif -%}
+                {{ section.settings.cover_image | image_url }} {{ section.settings.cover_image.width }}w"
               src="{{ section.settings.cover_image | image_url: width: 1920 }}"
               sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
               alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"
@@ -63,15 +63,15 @@
       >
         {%- if section.settings.cover_image != blank -%}
           <img
-            srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | image_url: width: 375 }},{%- endif -%}
-              {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | image_url: width: 750 }},{%- endif -%}
-              {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
-              {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
-              {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | image_url: width: 1780 }},{%- endif -%}
-              {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
-              {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
-              {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
-              {{ section.settings.cover_image | image_url: 'master' }}"
+            srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | image_url: width: 375 }} 375w,{%- endif -%}
+              {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | image_url: width: 750 }} 750w,{%- endif -%}
+              {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | image_url: width: 1100 }} 1100w,{%- endif -%}
+              {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | image_url: width: 1500 }} 1500w,{%- endif -%}
+              {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | image_url: width: 1780 }} 1780w,{%- endif -%}
+              {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }} 2000w,{%- endif -%}
+              {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }} 3000w,{%- endif -%}
+              {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }} 3840w,{%- endif -%}
+              {{ section.settings.cover_image | image_url }} {{ section.settings.cover_image}}w"
             src="{{ section.settings.cover_image | image_url: width: 1920 }}"
             sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
             alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"

--- a/sections/video.liquid
+++ b/sections/video.liquid
@@ -31,16 +31,16 @@
         <a href="{{ section.settings.video_url }}" class="video-section__poster media media--transparent media--landscape{% if section.settings.cover_image == blank %} video-section__placeholder{% endif %}">
           {%- if section.settings.cover_image != blank -%}
             <img
-              srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | img_url: '375x' }} 375w,{%- endif -%}
-                {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | img_url: '750x' }} 750w,{%- endif -%}
-                {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | img_url: '1100x' }} 1100w,{%- endif -%}
-                {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | img_url: '1500x' }} 1500w,{%- endif -%}
-                {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | img_url: '1780x' }} 1780w,{%- endif -%}
-                {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | img_url: '2000x' }} 2000w,{%- endif -%}
-                {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | img_url: '3000x' }} 3000w,{%- endif -%}
-                {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | img_url: '3840x' }} 3840w,{%- endif -%}
-                {{ section.settings.cover_image | img_url: 'master' }} {{ section.settings.cover_image.width }}w"
-              src="{{ section.settings.cover_image | img_url: '1920x' }}"
+              srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | image_url: width: 375 }},{%- endif -%}
+                {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | image_url: width: 750 }},{%- endif -%}
+                {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
+                {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
+                {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | image_url: width: 1780 }},{%- endif -%}
+                {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
+                {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
+                {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
+                {{ section.settings.cover_image | image_url: width: 'master' }} {{ section.settings.cover_image.width }}w"
+              src="{{ section.settings.cover_image | image_url: width: 1920 }}"
               sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
               alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"
               loading="lazy"
@@ -63,16 +63,16 @@
       >
         {%- if section.settings.cover_image != blank -%}
           <img
-            srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | img_url: '375x' }} 375w,{%- endif -%}
-              {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | img_url: '750x' }} 750w,{%- endif -%}
-              {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | img_url: '1100x' }} 1100w,{%- endif -%}
-              {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | img_url: '1500x' }} 1500w,{%- endif -%}
-              {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | img_url: '1780x' }} 1780w,{%- endif -%}
-              {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | img_url: '2000x' }} 2000w,{%- endif -%}
-              {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | img_url: '3000x' }} 3000w,{%- endif -%}
-              {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | img_url: '3840x' }} 3840w,{%- endif -%}
-              {{ section.settings.cover_image | img_url: 'master' }} {{ section.settings.cover_image.width }}w"
-            src="{{ section.settings.cover_image | img_url: '1920x' }}"
+            srcset="{%- if section.settings.cover_image.width >= 375 -%}{{ section.settings.cover_image | image_url: width: 375 }},{%- endif -%}
+              {%- if section.settings.cover_image.width >= 750 -%}{{ section.settings.cover_image | image_url: width: 750 }},{%- endif -%}
+              {%- if section.settings.cover_image.width >= 1100 -%}{{ section.settings.cover_image | image_url: width: 1100 }},{%- endif -%}
+              {%- if section.settings.cover_image.width >= 1500 -%}{{ section.settings.cover_image | image_url: width: 1500 }},{%- endif -%}
+              {%- if section.settings.cover_image.width >= 1780 -%}{{ section.settings.cover_image | image_url: width: 1780 }},{%- endif -%}
+              {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
+              {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
+              {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
+              {{ section.settings.cover_image | image_url: width: 'master' }} {{ section.settings.cover_image.width }}w"
+            src="{{ section.settings.cover_image | image_url: width: 1920 }}"
             sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
             alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"
             loading="lazy"

--- a/sections/video.liquid
+++ b/sections/video.liquid
@@ -39,7 +39,7 @@
                 {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
                 {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
                 {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
-                {{ section.settings.cover_image | image_url: height: 'master', width: section.settings.cover_image.width }}"
+                {{ section.settings.cover_image | image_url: 'master' }}"
               src="{{ section.settings.cover_image | image_url: width: 1920 }}"
               sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
               alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"
@@ -71,7 +71,7 @@
               {%- if section.settings.cover_image.width >= 2000 -%}{{ section.settings.cover_image | image_url: width: 2000 }},{%- endif -%}
               {%- if section.settings.cover_image.width >= 3000 -%}{{ section.settings.cover_image | image_url: width: 3000 }},{%- endif -%}
               {%- if section.settings.cover_image.width >= 3840 -%}{{ section.settings.cover_image | image_url: width: 3840 }},{%- endif -%}
-              {{ section.settings.cover_image | image_url: height: 'master', width: section.settings.cover_image.width }}"
+              {{ section.settings.cover_image | image_url: 'master' }}"
             src="{{ section.settings.cover_image | image_url: width: 1920 }}"
             sizes="{% if section.settings.full_width %}100vw{% else %}(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 }}px, (min-width: 750px) calc(100vw - 10rem), 100vw{% endif %}"
             alt="{{ 'sections.video.load_video' | t: description: section.settings.description | escape }}"

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -38,14 +38,14 @@
           <div class="article-card__image-wrapper card__media">
             <div class="article-card__image media media--hover-effect" {% if section.settings.media_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
               <img
-                srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | img_url: '165x' }} 165w,{%- endif -%}
-                  {%- if article.image.src.width >= 360 -%}{{ article.image.src | img_url: '360x' }} 360w,{%- endif -%}
-                  {%- if article.image.src.width >= 533 -%}{{ article.image.src | img_url: '533x' }} 533w,{%- endif -%}
-                  {%- if article.image.src.width >= 720 -%}{{ article.image.src | img_url: '720x' }} 720w,{%- endif -%}
-                  {%- if article.image.src.width >= 1000 -%}{{ article.image.src | img_url: '1000x' }} 1000w,{%- endif -%}
-                  {%- if article.image.src.width >= 1500 -%}{{ article.image.src | img_url: '1500x' }} 1500w,{%- endif -%}
-                  {{ article.image.src | img_url: 'master' }} {{ article.image.src.width }}w"
-                src="{{ article.image.src | img_url: '533x' }}"
+                srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | image_url: width: 165 }},{%- endif -%}
+                  {%- if article.image.src.width >= 360 -%}{{ article.image.src | image_url: width: 360 }},{%- endif -%}
+                  {%- if article.image.src.width >= 533 -%}{{ article.image.src | image_url: width: 533 }},{%- endif -%}
+                  {%- if article.image.src.width >= 720 -%}{{ article.image.src | image_url: width: 720 }},{%- endif -%}
+                  {%- if article.image.src.width >= 1000 -%}{{ article.image.src | image_url: width: 1000 }},{%- endif -%}
+                  {%- if article.image.src.width >= 1500 -%}{{ article.image.src | image_url: width: 1500 }},{%- endif -%}
+                  {{ article.image.src | image_url: width: 'master' }}"
+                src="{{ article.image.src | image_url: width: 533 }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                 alt="{{ article.image.src.alt | escape }}"
                 class="motion-reduce"

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -44,7 +44,7 @@
                   {%- if article.image.src.width >= 720 -%}{{ article.image.src | image_url: width: 720 }},{%- endif -%}
                   {%- if article.image.src.width >= 1000 -%}{{ article.image.src | image_url: width: 1000 }},{%- endif -%}
                   {%- if article.image.src.width >= 1500 -%}{{ article.image.src | image_url: width: 1500 }},{%- endif -%}
-                  {{ article.image.src | image_url: width: 'master' }}"
+                  {{ article.image.src | image_url: height: 'master', width: article.image.src.width }}"
                 src="{{ article.image.src | image_url: width: 533 }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                 alt="{{ article.image.src.alt | escape }}"

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -38,13 +38,13 @@
           <div class="article-card__image-wrapper card__media">
             <div class="article-card__image media media--hover-effect" {% if section.settings.media_height == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: article.image.aspect_ratio | times: 100 }}%;"{% endif %}>
               <img
-                srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | image_url: width: 165 }},{%- endif -%}
-                  {%- if article.image.src.width >= 360 -%}{{ article.image.src | image_url: width: 360 }},{%- endif -%}
-                  {%- if article.image.src.width >= 533 -%}{{ article.image.src | image_url: width: 533 }},{%- endif -%}
-                  {%- if article.image.src.width >= 720 -%}{{ article.image.src | image_url: width: 720 }},{%- endif -%}
-                  {%- if article.image.src.width >= 1000 -%}{{ article.image.src | image_url: width: 1000 }},{%- endif -%}
-                  {%- if article.image.src.width >= 1500 -%}{{ article.image.src | image_url: width: 1500 }},{%- endif -%}
-                  {{ article.image.src | image_url: 'master' }}"
+                srcset="{%- if article.image.src.width >= 165 -%}{{ article.image.src | image_url: width: 165 }} 165w,{%- endif -%}
+                  {%- if article.image.src.width >= 360 -%}{{ article.image.src | image_url: width: 360 }} 360w,{%- endif -%}
+                  {%- if article.image.src.width >= 533 -%}{{ article.image.src | image_url: width: 533 }} 533w,{%- endif -%}
+                  {%- if article.image.src.width >= 720 -%}{{ article.image.src | image_url: width: 720 }} 720w,{%- endif -%}
+                  {%- if article.image.src.width >= 1000 -%}{{ article.image.src | image_url: width: 1000 }} 1000w,{%- endif -%}
+                  {%- if article.image.src.width >= 1500 -%}{{ article.image.src | image_url: width: 1500 }} 1500w,{%- endif -%}
+                  {{ article.image.src | image_url }} {{ article.image.src.width }}w"
                 src="{{ article.image.src | image_url: width: 533 }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                 alt="{{ article.image.src.alt | escape }}"

--- a/snippets/article-card.liquid
+++ b/snippets/article-card.liquid
@@ -44,7 +44,7 @@
                   {%- if article.image.src.width >= 720 -%}{{ article.image.src | image_url: width: 720 }},{%- endif -%}
                   {%- if article.image.src.width >= 1000 -%}{{ article.image.src | image_url: width: 1000 }},{%- endif -%}
                   {%- if article.image.src.width >= 1500 -%}{{ article.image.src | image_url: width: 1500 }},{%- endif -%}
-                  {{ article.image.src | image_url: height: 'master', width: article.image.src.width }}"
+                  {{ article.image.src | image_url: 'master' }}"
                 src="{{ article.image.src | image_url: width: 533 }}"
                 sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: 2 }}px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
                 alt="{{ article.image.src.alt | escape }}"

--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -44,7 +44,7 @@
                 {%- if card_collection.featured_image.width >= 1000 -%}{{ card_collection.featured_image | image_url: width: 1000 }},{%- endif -%}
                 {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500 }},{%- endif -%}
                 {%- if card_collection.featured_image.width >= 3000 -%}{{ card_collection.featured_image | image_url: width: 3000 }},{%- endif -%}
-                {{ card_collection.featured_image | image_url: width: 'master' }}"
+                {{ card_collection.featured_image | image_url: height: 'master', width: card_collection.featured_image.width }}"
               src="{{ card_collection.featured_image | image_url: width: 1500 }}"
               sizes="
               (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,

--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -37,14 +37,14 @@
         <div class="card__media">
           <div class="media media--transparent media--hover-effect">
             <img
-              srcset="{%- if card_collection.featured_image.width >= 165 -%}{{ card_collection.featured_image | image_url: width: 165 }},{%- endif -%}
-                {%- if card_collection.featured_image.width >= 330 -%}{{ card_collection.featured_image | image_url: width: 330 }},{%- endif -%}
-                {%- if card_collection.featured_image.width >= 535 -%}{{ card_collection.featured_image | image_url: width: 535 }},{%- endif -%}
-                {%- if card_collection.featured_image.width >= 750 -%}{{ card_collection.featured_image | image_url: width: 750 }},{%- endif -%}
-                {%- if card_collection.featured_image.width >= 1000 -%}{{ card_collection.featured_image | image_url: width: 1000 }},{%- endif -%}
-                {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500 }},{%- endif -%}
-                {%- if card_collection.featured_image.width >= 3000 -%}{{ card_collection.featured_image | image_url: width: 3000 }},{%- endif -%}
-                {{ card_collection.featured_image | image_url: 'master' }}"
+              srcset="{%- if card_collection.featured_image.width >= 165 -%}{{ card_collection.featured_image | image_url: width: 165 }} 165w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 330 -%}{{ card_collection.featured_image | image_url: width: 330 }} 330w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 535 -%}{{ card_collection.featured_image | image_url: width: 535 }} 535w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 750 -%}{{ card_collection.featured_image | image_url: width: 750 }} 750w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1000 -%}{{ card_collection.featured_image | image_url: width: 1000 }} 1000w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500 }} 1500w,{%- endif -%}
+                {%- if card_collection.featured_image.width >= 3000 -%}{{ card_collection.featured_image | image_url: width: 3000 }} 3000w,{%- endif -%}
+                {{ card_collection.featured_image | image_url }} {{ card_collection.featured_image.width }}w"
               src="{{ card_collection.featured_image | image_url: width: 1500 }}"
               sizes="
               (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,

--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -37,15 +37,15 @@
         <div class="card__media">
           <div class="media media--transparent media--hover-effect">
             <img
-              srcset="{%- if card_collection.featured_image.width >= 165 -%}{{ card_collection.featured_image | img_url: '165x' }} 165w,{%- endif -%}
-                {%- if card_collection.featured_image.width >= 330 -%}{{ card_collection.featured_image | img_url: '330x' }} 330w,{%- endif -%}
-                {%- if card_collection.featured_image.width >= 535 -%}{{ card_collection.featured_image | img_url: '535x' }} 535w,{%- endif -%}
-                {%- if card_collection.featured_image.width >= 750 -%}{{ card_collection.featured_image | img_url: '750x' }} 750w,{%- endif -%}
-                {%- if card_collection.featured_image.width >= 1000 -%}{{ card_collection.featured_image | img_url: '1000x' }} 1000w,{%- endif -%}
-                {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | img_url: '1500x' }} 1500w,{%- endif -%}
-                {%- if card_collection.featured_image.width >= 3000 -%}{{ card_collection.featured_image | img_url: '3000x' }} 3000w,{%- endif -%}
-                {{ card_collection.featured_image | img_url: 'master' }} {{ card_collection.featured_image.width }}w"
-              src="{{ card_collection.featured_image | img_url: '1500x' }}"
+              srcset="{%- if card_collection.featured_image.width >= 165 -%}{{ card_collection.featured_image | image_url: width: 165 }},{%- endif -%}
+                {%- if card_collection.featured_image.width >= 330 -%}{{ card_collection.featured_image | image_url: width: 330 }},{%- endif -%}
+                {%- if card_collection.featured_image.width >= 535 -%}{{ card_collection.featured_image | image_url: width: 535 }},{%- endif -%}
+                {%- if card_collection.featured_image.width >= 750 -%}{{ card_collection.featured_image | image_url: width: 750 }},{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1000 -%}{{ card_collection.featured_image | image_url: width: 1000 }},{%- endif -%}
+                {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500 }},{%- endif -%}
+                {%- if card_collection.featured_image.width >= 3000 -%}{{ card_collection.featured_image | image_url: width: 3000 }},{%- endif -%}
+                {{ card_collection.featured_image | image_url: width: 'master' }}"
+              src="{{ card_collection.featured_image | image_url: width: 1500 }}"
               sizes="
               (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,
               (min-width: 750px) {% if columns > 1 %}calc((100vw - 10rem) / 2){% else %}calc(100vw - 10rem){% endif %},

--- a/snippets/card-collection.liquid
+++ b/snippets/card-collection.liquid
@@ -44,7 +44,7 @@
                 {%- if card_collection.featured_image.width >= 1000 -%}{{ card_collection.featured_image | image_url: width: 1000 }},{%- endif -%}
                 {%- if card_collection.featured_image.width >= 1500 -%}{{ card_collection.featured_image | image_url: width: 1500 }},{%- endif -%}
                 {%- if card_collection.featured_image.width >= 3000 -%}{{ card_collection.featured_image | image_url: width: 3000 }},{%- endif -%}
-                {{ card_collection.featured_image | image_url: height: 'master', width: card_collection.featured_image.width }}"
+                {{ card_collection.featured_image | image_url: 'master' }}"
               src="{{ card_collection.featured_image | image_url: width: 1500 }}"
               sizes="
               (min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | divided_by: columns }}px,

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -22,8 +22,8 @@
 <meta property="og:description" content="{{ og_description | escape }}">
 
 {%- if page_image -%}
-  <meta property="og:image" content="http:{{ page_image | img_url: 'master' }}">
-  <meta property="og:image:secure_url" content="https:{{ page_image | img_url: 'master' }}">
+  <meta property="og:image" content="http:{{ page_image | image_url: width: 'master' }}">
+  <meta property="og:image:secure_url" content="https:{{ page_image | image_url: width: 'master' }}">
   <meta property="og:image:width" content="{{ page_image.width }}">
   <meta property="og:image:height" content="{{ page_image.height }}">
 {%- endif -%}

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -22,8 +22,8 @@
 <meta property="og:description" content="{{ og_description | escape }}">
 
 {%- if page_image -%}
-  <meta property="og:image" content="http:{{ page_image | image_url: width: 'master' }}">
-  <meta property="og:image:secure_url" content="https:{{ page_image | image_url: width: 'master' }}">
+  <meta property="og:image" content="http:{{ page_image | image_url }}">
+  <meta property="og:image:secure_url" content="https:{{ page_image | image_url }}">
   <meta property="og:image:width" content="{{ page_image.width }}">
   <meta property="og:image:height" content="{{ page_image.height }}">
 {%- endif -%}

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -25,7 +25,7 @@
             {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | image_url: width: 2200 }},{%- endif -%}
             {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | image_url: width: 2890 }},{%- endif -%}
             {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | image_url: width: 4096 }},{%- endif -%}
-            {{ media.preview_image | image_url: width: 'master' }}"
+            {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
     sizes="(min-width: 750px) calc(100vw - 22rem), 1100px"
     src="{{ media.preview_image | image_url: width: 1445 }}"
     alt="{{ media.alt | escape }}"
@@ -56,7 +56,7 @@
                 {% if media.preview_image.width >= 576 %}{{ media.preview_image | image_url: width: 576 }},{% endif %}
                 {% if media.preview_image.width >= 550 %}{{ media.preview_image | image_url: width: 550 }},{% endif %}
                 {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
-                {{ media.preview_image | image_url: width: 'master' }}"
+                {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
         src="{{ media | image_url: width: 550 }}"
         sizes="(min-width: 1200px) calc((1200px - 10rem) / 2), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         loading="lazy"

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -25,7 +25,7 @@
             {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | image_url: width: 2200 }},{%- endif -%}
             {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | image_url: width: 2890 }},{%- endif -%}
             {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | image_url: width: 4096 }},{%- endif -%}
-            {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
+            {{ media.preview_image | image_url: 'master' }}"
     sizes="(min-width: 750px) calc(100vw - 22rem), 1100px"
     src="{{ media.preview_image | image_url: width: 1445 }}"
     alt="{{ media.alt | escape }}"
@@ -56,7 +56,7 @@
                 {% if media.preview_image.width >= 576 %}{{ media.preview_image | image_url: width: 576 }},{% endif %}
                 {% if media.preview_image.width >= 550 %}{{ media.preview_image | image_url: width: 550 }},{% endif %}
                 {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
-                {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
+                {{ media.preview_image | image_url: 'master' }}"
         src="{{ media | image_url: width: 550 }}"
         sizes="(min-width: 1200px) calc((1200px - 10rem) / 2), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         loading="lazy"

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -17,17 +17,17 @@
 {%- if media.media_type == 'image' -%}
   <img
     class="global-media-settings global-media-settings--no-shadow"
-    srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | img_url: '550x' }} 550w,{%- endif -%}
-            {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | img_url: '1100x' }} 1100w,{%- endif -%}
-            {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | img_url: '1445x' }} 1445w,{%- endif -%}
-            {%- if media.preview_image.width >= 1680 -%}{{ media.preview_image | img_url: '1680x' }} 1680w,{%- endif -%}
-            {%- if media.preview_image.width >= 2048 -%}{{ media.preview_image | img_url: '2048x' }} 2048w,{%- endif -%}
-            {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | img_url: '2200x' }} 2200w,{%- endif -%}
-            {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | img_url: '2890x' }} 2890w,{%- endif -%}
-            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | img_url: '4096x' }} 4096w,{%- endif -%}
-            {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
+    srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | image_url: 550 }},{%- endif -%}
+            {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | image_url: 1100 }},{%- endif -%}
+            {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | image_url: 1445 }},{%- endif -%}
+            {%- if media.preview_image.width >= 1680 -%}{{ media.preview_image | image_url: 1680 }},{%- endif -%}
+            {%- if media.preview_image.width >= 2048 -%}{{ media.preview_image | image_url: 2048 }},{%- endif -%}
+            {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | image_url: 2200 }},{%- endif -%}
+            {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | image_url: 2890 }},{%- endif -%}
+            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | image_url: 4096 }},{%- endif -%}
+            {{ media.preview_image | image_url: width: 'master' }}"
     sizes="(min-width: 750px) calc(100vw - 22rem), 1100px"
-    src="{{ media.preview_image | img_url: '1445x' }}"
+    src="{{ media.preview_image | image_url: width: 1445 }}"
     alt="{{ media.alt | escape }}"
     loading="lazy"
     width="1100"
@@ -52,12 +52,12 @@
         {%- endif -%}
       </span>
       <img
-        srcset="{% if media.preview_image.width >= 288 %}{{ media.preview_image | img_url: '288x' }} 288w,{% endif %}
-                {% if media.preview_image.width >= 576 %}{{ media.preview_image | img_url: '576x' }} 576w,{% endif %}
-                {% if media.preview_image.width >= 550 %}{{ media.preview_image | img_url: '550x' }} 550w,{% endif %}
-                {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
-                {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-        src="{{ media | img_url: '550x550' }}"
+        srcset="{% if media.preview_image.width >= 288 %}{{ media.preview_image | image_url: width: 288 }},{% endif %}
+                {% if media.preview_image.width >= 576 %}{{ media.preview_image | image_url: width: 576 }},{% endif %}
+                {% if media.preview_image.width >= 550 %}{{ media.preview_image | image_url: width: 550 }},{% endif %}
+                {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
+                {{ media.preview_image | image_url: width: 'master' }}"
+        src="{{ media | image_url: width: 550 }}"
         sizes="(min-width: 1200px) calc((1200px - 10rem) / 2), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         loading="lazy"
         width="576"

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -17,15 +17,15 @@
 {%- if media.media_type == 'image' -%}
   <img
     class="global-media-settings global-media-settings--no-shadow"
-    srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | image_url: width: 550 }},{%- endif -%}
-            {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | image_url: width: 1100 }},{%- endif -%}
-            {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | image_url: width: 1445 }},{%- endif -%}
-            {%- if media.preview_image.width >= 1680 -%}{{ media.preview_image | image_url: width: 1680 }},{%- endif -%}
-            {%- if media.preview_image.width >= 2048 -%}{{ media.preview_image | image_url: width: 2048 }},{%- endif -%}
-            {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | image_url: width: 2200 }},{%- endif -%}
-            {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | image_url: width: 2890 }},{%- endif -%}
-            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | image_url: width: 4096 }},{%- endif -%}
-            {{ media.preview_image | image_url: 'master' }}"
+    srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | image_url: width: 550 }} 550w,{%- endif -%}
+            {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | image_url: width: 1100 }} 1100w,{%- endif -%}
+            {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | image_url: width: 1445 }} 1445w,{%- endif -%}
+            {%- if media.preview_image.width >= 1680 -%}{{ media.preview_image | image_url: width: 1680 }} 1680w,{%- endif -%}
+            {%- if media.preview_image.width >= 2048 -%}{{ media.preview_image | image_url: width: 2048 }} 2048w,{%- endif -%}
+            {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | image_url: width: 2200 }} 2200w,{%- endif -%}
+            {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | image_url: width: 2890 }} 2890w,{%- endif -%}
+            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | image_url: width: 4096 }} 4096w,{%- endif -%}
+            {{ media.preview_image | image_url }} {{ media.preview_image.width }}w"
     sizes="(min-width: 750px) calc(100vw - 22rem), 1100px"
     src="{{ media.preview_image | image_url: width: 1445 }}"
     alt="{{ media.alt | escape }}"
@@ -52,11 +52,11 @@
         {%- endif -%}
       </span>
       <img
-        srcset="{% if media.preview_image.width >= 288 %}{{ media.preview_image | image_url: width: 288 }},{% endif %}
-                {% if media.preview_image.width >= 576 %}{{ media.preview_image | image_url: width: 576 }},{% endif %}
-                {% if media.preview_image.width >= 550 %}{{ media.preview_image | image_url: width: 550 }},{% endif %}
-                {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
-                {{ media.preview_image | image_url: 'master' }}"
+        srcset="{% if media.preview_image.width >= 288 %}{{ media.preview_image | image_url: width: 288 }} 288w,{% endif %}
+                {% if media.preview_image.width >= 576 %}{{ media.preview_image | image_url: width: 576 }} 576w,{% endif %}
+                {% if media.preview_image.width >= 550 %}{{ media.preview_image | image_url: width: 550 }} 550w,{% endif %}
+                {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }} 1100w,{% endif %}
+                {{ media.preview_image | image_url }} {{ media.preview_image }}w"
         src="{{ media | image_url: width: 550 }}"
         sizes="(min-width: 1200px) calc((1200px - 10rem) / 2), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         loading="lazy"

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -17,14 +17,14 @@
 {%- if media.media_type == 'image' -%}
   <img
     class="global-media-settings global-media-settings--no-shadow"
-    srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | image_url: 550 }},{%- endif -%}
-            {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | image_url: 1100 }},{%- endif -%}
-            {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | image_url: 1445 }},{%- endif -%}
-            {%- if media.preview_image.width >= 1680 -%}{{ media.preview_image | image_url: 1680 }},{%- endif -%}
-            {%- if media.preview_image.width >= 2048 -%}{{ media.preview_image | image_url: 2048 }},{%- endif -%}
-            {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | image_url: 2200 }},{%- endif -%}
-            {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | image_url: 2890 }},{%- endif -%}
-            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | image_url: 4096 }},{%- endif -%}
+    srcset="{%- if media.preview_image.width >= 550 -%}{{ media.preview_image | image_url: width: 550 }},{%- endif -%}
+            {%- if media.preview_image.width >= 1100 -%}{{ media.preview_image | image_url: width: 1100 }},{%- endif -%}
+            {%- if media.preview_image.width >= 1445 -%}{{ media.preview_image | image_url: width: 1445 }},{%- endif -%}
+            {%- if media.preview_image.width >= 1680 -%}{{ media.preview_image | image_url: width: 1680 }},{%- endif -%}
+            {%- if media.preview_image.width >= 2048 -%}{{ media.preview_image | image_url: width: 2048 }},{%- endif -%}
+            {%- if media.preview_image.width >= 2200 -%}{{ media.preview_image | image_url: width: 2200 }},{%- endif -%}
+            {%- if media.preview_image.width >= 2890 -%}{{ media.preview_image | image_url: width: 2890 }},{%- endif -%}
+            {%- if media.preview_image.width >= 4096 -%}{{ media.preview_image | image_url: width: 4096 }},{%- endif -%}
             {{ media.preview_image | image_url: width: 'master' }}"
     sizes="(min-width: 750px) calc(100vw - 22rem), 1100px"
     src="{{ media.preview_image | image_url: width: 1445 }}"

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -35,7 +35,7 @@
           {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
           {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
           {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-          {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
+          {{ media.preview_image | image_url: 'master' }}"
         src="{{ media | image_url: width: 1946 }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -61,7 +61,7 @@
           {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
           {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
           {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-          {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
+          {{ media.preview_image | image_url: 'master' }}"
         src="{{ media | image_url: width: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -100,7 +100,7 @@
         {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
         {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
         {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-        {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
+        {{ media.preview_image | image_url: 'master' }}"
       src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -144,7 +144,7 @@
         {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
         {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
         {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-        {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
+        {{ media.preview_image | image_url: 'master' }}"
       src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -35,7 +35,7 @@
           {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
           {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
           {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-          {{ media.preview_image | image_url: width: 'master' }}"
+          {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
         src="{{ media | image_url: width: 1946 }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -61,7 +61,7 @@
           {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
           {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
           {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-          {{ media.preview_image | image_url: width: 'master' }}"
+          {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
         src="{{ media | image_url: width: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -100,7 +100,7 @@
         {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
         {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
         {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-        {{ media.preview_image | image_url: width: 'master' }}"
+        {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
       src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -144,7 +144,7 @@
         {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
         {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
         {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-        {{ media.preview_image | image_url: width: 'master' }}"
+        {{ media.preview_image | image_url: height: 'master', width: media.preview_image.width }}"
       src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -24,19 +24,19 @@
     <span class="product__media-icon motion-reduce">{% render 'icon-play' %}</span>
     <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
-        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
-          {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
-          {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
-          {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
-          {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
-          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
-          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
-          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
-          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
-          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
-          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
-          {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-        src="{{ media | img_url: '1946x' }}"
+        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
+          {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
+          {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
+          {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
+          {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
+          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
+          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
+          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
+          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
+          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
+          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
+          {{ media.preview_image | image_url: width: 'master' }}"
+        src="{{ media | image_url: width: 1946 }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
         width="973"
@@ -50,19 +50,19 @@
   {%- else -%}
     <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
-        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
-          {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
-          {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
-          {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
-          {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
-          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
-          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
-          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
-          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
-          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
-          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
-          {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-        src="{{ media | img_url: '1946x' }}"
+        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
+          {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
+          {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
+          {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
+          {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
+          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
+          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
+          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
+          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
+          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
+          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
+          {{ media.preview_image | image_url: width: 'master' }}"
+        src="{{ media | image_url: width: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
         width="973"
@@ -89,19 +89,19 @@
 
   <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
     <img
-      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
-        {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
-        {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
-        {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
-        {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
-        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
-        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
-        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
-        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
-        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
-        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
-        {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-      src="{{ media | img_url: '1946x' }}"
+      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
+        {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
+        {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
+        {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
+        {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
+        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
+        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
+        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
+        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
+        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
+        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
+        {{ media.preview_image | image_url: width: 'master' }}"
+      src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}
       width="973"
@@ -133,19 +133,19 @@
       {%- endif -%}
     </span>
     <img
-      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | img_url: '493x' }} 493w,{% endif %}
-        {% if media.preview_image.width >= 600 %}{{ media.preview_image | img_url: '600x' }} 600w,{% endif %}
-        {% if media.preview_image.width >= 713 %}{{ media.preview_image | img_url: '713x' }} 713w,{% endif %}
-        {% if media.preview_image.width >= 823 %}{{ media.preview_image | img_url: '823x' }} 823w,{% endif %}
-        {% if media.preview_image.width >= 990 %}{{ media.preview_image | img_url: '990x' }} 990w,{% endif %}
-        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | img_url: '1100x' }} 1100w,{% endif %}
-        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | img_url: '1206x' }} 1206w,{% endif %}
-        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | img_url: '1346x' }} 1346w,{% endif %}
-        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | img_url: '1426x' }} 1426w,{% endif %}
-        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | img_url: '1646x' }} 1646w,{% endif %}
-        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | img_url: '1946x' }} 1946w,{% endif %}
-        {{ media.preview_image | img_url: 'master' }} {{ media.preview_image.width }}w"
-      src="{{ media | img_url: '1946x' }}"
+      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
+        {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
+        {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
+        {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
+        {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
+        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
+        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
+        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
+        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
+        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
+        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
+        {{ media.preview_image | image_url: width: 'master' }}"
+      src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}
       width="973"

--- a/snippets/product-thumbnail.liquid
+++ b/snippets/product-thumbnail.liquid
@@ -24,18 +24,18 @@
     <span class="product__media-icon motion-reduce">{% render 'icon-play' %}</span>
     <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
-        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
-          {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
-          {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
-          {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
-          {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
-          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
-          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
-          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
-          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
-          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
-          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-          {{ media.preview_image | image_url: 'master' }}"
+        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }} 493w,{% endif %}
+          {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }} 600w,{% endif %}
+          {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }} 713w,{% endif %}
+          {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }} 823w,{% endif %}
+          {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }} 990w,{% endif %}
+          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }} 1100w,{% endif %}
+          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }} 1206w,{% endif %}
+          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }} 1346w,{% endif %}
+          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }} 1426w,{% endif %}
+          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }} 1646w,{% endif %}
+          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }} 1946w,{% endif %}
+          {{ media.preview_image | image_url }} {{ media.preview_image.width }}w"
         src="{{ media | image_url: width: 1946 }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -50,18 +50,18 @@
   {%- else -%}
     <div class="product__media media gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
       <img
-        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
-          {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
-          {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
-          {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
-          {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
-          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
-          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
-          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
-          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
-          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
-          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-          {{ media.preview_image | image_url: 'master' }}"
+        srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }} 493w,{% endif %}
+          {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }} 600w,{% endif %}
+          {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }} 713w,{% endif %}
+          {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }} 823w,{% endif %}
+          {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }} 990w,{% endif %}
+          {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }} 1100w,{% endif %}
+          {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }} 1206w,{% endif %}
+          {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }} 1346w,{% endif %}
+          {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }} 1426w,{% endif %}
+          {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }} 1646w,{% endif %}
+          {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }} 1946w,{% endif %}
+          {{ media.preview_image | image_url }} {{ media.preview_image.width }}w"
         src="{{ media | image_url: width: '1946x' }}"
         sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
         {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -89,18 +89,18 @@
 
   <div class="product__media media media--transparent gradient global-media-settings" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
     <img
-      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
-        {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
-        {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
-        {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
-        {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
-        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
-        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
-        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
-        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
-        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
-        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-        {{ media.preview_image | image_url: 'master' }}"
+      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }} 493w,{% endif %}
+        {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }} 600w,{% endif %}
+        {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }} 713w,{% endif %}
+        {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }} 823w,{% endif %}
+        {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }} 990w,{% endif %}
+        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }} 1100w,{% endif %}
+        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }} 1206w,{% endif %}
+        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }} 1346w,{% endif %}
+        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }} 1426w,{% endif %}
+        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }} 1646w,{% endif %}
+        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }} 1946w,{% endif %}
+        {{ media.preview_image | image_url }} {{ media.preview_image.width }}w"
       src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}
@@ -133,18 +133,18 @@
       {%- endif -%}
     </span>
     <img
-      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }},{% endif %}
-        {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }},{% endif %}
-        {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }},{% endif %}
-        {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }},{% endif %}
-        {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }},{% endif %}
-        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }},{% endif %}
-        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }},{% endif %}
-        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }},{% endif %}
-        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }},{% endif %}
-        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }},{% endif %}
-        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }},{% endif %}
-        {{ media.preview_image | image_url: 'master' }}"
+      srcset="{% if media.preview_image.width >= 493 %}{{ media.preview_image | image_url: width: 493 }} 493w,{% endif %}
+        {% if media.preview_image.width >= 600 %}{{ media.preview_image | image_url: width: 600 }} 600w,{% endif %}
+        {% if media.preview_image.width >= 713 %}{{ media.preview_image | image_url: width: 713 }} 713w,{% endif %}
+        {% if media.preview_image.width >= 823 %}{{ media.preview_image | image_url: width: 823 }} 823w,{% endif %}
+        {% if media.preview_image.width >= 990 %}{{ media.preview_image | image_url: width: 990 }} 990w,{% endif %}
+        {% if media.preview_image.width >= 1100 %}{{ media.preview_image | image_url: width: 1100 }} 1100w,{% endif %}
+        {% if media.preview_image.width >= 1206 %}{{ media.preview_image | image_url: width: 1206 }} 1206w,{% endif %}
+        {% if media.preview_image.width >= 1346 %}{{ media.preview_image | image_url: width: 1346 }} 1346w,{% endif %}
+        {% if media.preview_image.width >= 1426 %}{{ media.preview_image | image_url: width: 1426 }} 1426w,{% endif %}
+        {% if media.preview_image.width >= 1646 %}{{ media.preview_image | image_url: width: 1646 }} 1646w,{% endif %}
+        {% if media.preview_image.width >= 1946 %}{{ media.preview_image | image_url: width: 1946 }} 1946w,{% endif %}
+        {{ media.preview_image | image_url }} {{ media.preview_image }}w"
       src="{{ media | image_url: width: 1946 }}"
       sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 100 | times: media_width | round }}px, (min-width: 990px) calc({{ media_width | times: 100 }}vw - 10rem), (min-width: 750px) calc((100vw - 11.5rem) / 2), calc(100vw - 4rem)"
       {% unless lazy_load == false %}loading="lazy"{% endunless %}

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
 
     {%- if settings.favicon != blank -%}
-      <link rel="icon" type="image/png" href="{{ settings.favicon | img_url: '32x32' }}">
+      <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: width: 32 }}">
     {%- endif -%}
 
     {%- unless settings.type_header_font.system? -%}


### PR DESCRIPTION
A simple fix to for the img_url linting warning, as it is deprecated, in case anyone needs to start with a fresh copy of the theme. Note; 'scale' is unsupported with image_src, but I was unable to find a replacement. Cheers mate.